### PR TITLE
fix: restore draft release inputs & tighten version classification

### DIFF
--- a/.github/workflows/create-release.lock.yml
+++ b/.github/workflows/create-release.lock.yml
@@ -23,7 +23,7 @@
 #
 # Analyzes changes since the last release, selects the best semantic version increment, generates release notes, creates a draft GitHub release, and opens a review issue for human approval before the release is published.
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"907c34fa54509d6748cd1f34b984874072242824b4945a79968312e0e71512b2","compiler_version":"v0.55.0","strict":true}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"fb051cbe53d98e340388562c128249a34f7e07f2f7e5886bdfe64ce3c82fe56e","compiler_version":"v0.55.0","strict":true}
 
 name: "Create Release"
 "on":
@@ -313,7 +313,7 @@ jobs:
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
           cat > /opt/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_EOF'
-          {"create-draft-release":{"description":"Creates a draft GitHub release with the specified version tag, title, and release notes. The release is created as a draft so a human can review and publish it. Returns the URL of the releases page.\n","inputs":{"prerelease":{"default":null,"description":"Set to 'true' if this is a pre-release (alpha/beta/rc)","required":false,"type":"string"},"release_name":{"default":null,"description":"Human-readable release title (e.g. Augustus 1.2.3)","required":true,"type":"string"},"release_notes":{"default":null,"description":"Markdown-formatted release notes","required":true,"type":"string"},"tag_name":{"default":null,"description":"Version tag for the release (e.g. v1.2.3)","required":true,"type":"string"}}},"create_issue":{"max":1},"missing_data":{},"missing_tool":{},"noop":{"max":1}}
+          {"create_draft_release":{"description":"Creates a draft GitHub release with the specified version tag, title, and release notes. The release is created as a draft so a human can review and publish it. Returns the URL of the releases page.\n","inputs":{"prerelease":{"default":null,"description":"Set to 'true' if this is a pre-release (alpha/beta/rc)","required":false,"type":"string"},"release_name":{"default":null,"description":"Human-readable release title (e.g. Augustus 1.2.3)","required":true,"type":"string"},"release_notes":{"default":null,"description":"Markdown-formatted release notes","required":true,"type":"string"},"tag_name":{"default":null,"description":"Version tag for the release (e.g. v1.2.3)","required":true,"type":"string"}}},"create_issue":{"max":1},"missing_data":{},"missing_tool":{},"noop":{"max":1}}
           GH_AW_SAFE_OUTPUTS_CONFIG_EOF
           cat > /opt/gh-aw/safeoutputs/tools.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_EOF'
           [

--- a/.github/workflows/create-release.md
+++ b/.github/workflows/create-release.md
@@ -30,7 +30,7 @@ safe-outputs:
     title-prefix: "[Release Review] "
     labels: [release]
   jobs:
-    create-draft-release:
+    create_draft_release:
       description: >
         Creates a draft GitHub release with the specified version tag, title,
         and release notes. The release is created as a draft so a human can


### PR DESCRIPTION
## Summary

- **Restore safe-output inputs**: `tag_name`, `release_name`, `release_notes` were accidentally removed in 458a5d3, causing the agent to emit `null` values and the `safe_outputs` handler to fail with "No handler loaded for type 'create_draft_release'"
- **Tighten MINOR vs PATCH rules**: MINOR now requires new public-facing API surface. Internal changes (security hardening, CI, tests, docs) are always PATCH — prevents incorrect bumps like v0.3.0 for purely internal work
- **Add "common mistake" callout**: Explicit guidance to prevent misclassifying internal improvements as new features

Fixes workflow run [#22801073726](https://github.com/chrisjainsley/Augustus/actions/runs/22801073726).