### PR TITLE
fix: set base-branch to master for NuGet update PR creation

### DIFF
--- a/.github/workflows/nuget-update.lock.yml
+++ b/.github/workflows/nuget-update.lock.yml
@@ -23,7 +23,7 @@
 #
 # Automatically updates NuGet packages across the solution, fixes any breaking changes introduced by the updates while preserving the public API surface, ensures the project builds and tests pass, then opens a pull request for review.
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"e3a8df6ef68a68ade232c0fc04678724f324f69516411bff0c5e06d20eab2387","compiler_version":"v0.55.0","strict":true}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"848177063794e2127da6bb2f960d68dea605795edba50c38622cf83f046a1514","compiler_version":"v0.55.0","strict":true}
 
 name: "NuGet Package Update"
 "on":
@@ -324,7 +324,7 @@ jobs:
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
           cat > /opt/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_EOF'
-          {"add_comment":{"max":1},"create_issue":{"max":1},"create_pull_request":{"draft":true,"fallback_as_issue":true,"max":1,"reviewers":["copilot"],"title_prefix":"[NuGet Update] "},"missing_data":{},"missing_tool":{},"noop":{"max":1}}
+          {"add_comment":{"max":1},"create_issue":{"max":1},"create_pull_request":{"base_branch":"master","draft":true,"fallback_as_issue":true,"max":1,"reviewers":["copilot"],"title_prefix":"[NuGet Update] "},"missing_data":{},"missing_tool":{},"noop":{"max":1}}
           GH_AW_SAFE_OUTPUTS_CONFIG_EOF
           cat > /opt/gh-aw/safeoutputs/tools.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_EOF'
           [
@@ -1278,7 +1278,7 @@ jobs:
         if: ((!cancelled()) && (needs.agent.result != 'skipped')) && (contains(needs.agent.outputs.output_types, 'create_pull_request'))
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ github.base_ref || github.event.pull_request.base.ref || github.ref_name || github.event.repository.default_branch }}
+          ref: master
           token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           persist-credentials: false
           fetch-depth: 1
@@ -1304,7 +1304,7 @@ jobs:
           GH_AW_ALLOWED_DOMAINS: "*.vsblob.vsassets.io,api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.nuget.org,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,azuresearch-usnc.nuget.org,azuresearch-ussc.nuget.org,builds.dotnet.microsoft.com,ci.dot.net,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,dc.services.visualstudio.com,dist.nuget.org,dot.net,dotnet.microsoft.com,dotnetcli.blob.core.windows.net,github.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,nuget.org,nuget.pkg.github.com,nugetregistryv2prod.blob.core.windows.net,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,oneocsp.microsoft.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,pkgs.dev.azure.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.microsoft.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"max\":1},\"create_issue\":{\"labels\":[\"dependencies\",\"automation\"],\"max\":1,\"title_prefix\":\"[NuGet Update] \"},\"create_pull_request\":{\"draft\":true,\"fallback_as_issue\":true,\"labels\":[\"dependencies\",\"automation\"],\"max\":1,\"max_patch_size\":1024,\"reviewers\":[\"copilot\"],\"title_prefix\":\"[NuGet Update] \"},\"missing_data\":{},\"missing_tool\":{}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"max\":1},\"create_issue\":{\"labels\":[\"dependencies\",\"automation\"],\"max\":1,\"title_prefix\":\"[NuGet Update] \"},\"create_pull_request\":{\"base_branch\":\"master\",\"draft\":true,\"fallback_as_issue\":true,\"labels\":[\"dependencies\",\"automation\"],\"max\":1,\"max_patch_size\":1024,\"reviewers\":[\"copilot\"],\"title_prefix\":\"[NuGet Update] \"},\"missing_data\":{},\"missing_tool\":{}}"
           GH_AW_CI_TRIGGER_TOKEN: ${{ secrets.GH_AW_CI_TRIGGER_TOKEN }}
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nuget-update.md
+++ b/.github/workflows/nuget-update.md
@@ -44,6 +44,7 @@ safe-outputs:
     reviewers: [copilot]
     draft: true
     max: 1
+    base-branch: "master"
     fallback-as-issue: true
   create-issue:
     max: 1


### PR DESCRIPTION
## What changed

Added `base-branch: "master"` to the `create-pull-request` safe output config in the NuGet update agentic workflow.

## Why

The safe_outputs job auto-detected `main` as the base branch, but this repo uses `master`. This caused the PR creation step to fail:

```
Base branch for chrisjainsley/Augustus: main
fatal: couldn't find remote ref main
✗ Message 1 (create_pull_request) failed
```

From [run #22803642294](https://github.com/chrisjainsley/Augustus/actions/runs/22803642294) — the agent successfully updated all 6 NuGet packages and passed all tests, but the final PR creation failed.

## Test plan

- [ ] Merge and re-run `NuGet Package Update` workflow with `dry_run=false`
- [ ] Verify the draft PR is created targeting `master`

🤖 Generated with [Claude Code](https://claude.com/claude-code)