### PR TITLE
chore: rename workflow to Dependency Updater

### DIFF
--- a/.github/workflows/nuget-update.lock.yml
+++ b/.github/workflows/nuget-update.lock.yml
@@ -23,9 +23,9 @@
 #
 # Automatically updates NuGet packages across the solution, fixes any breaking changes introduced by the updates while preserving the public API surface, ensures the project builds and tests pass, then opens a pull request for review.
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"848177063794e2127da6bb2f960d68dea605795edba50c38622cf83f046a1514","compiler_version":"v0.55.0","strict":true}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"0dddb1d151f0fec366e2b51b284d244c82668b658ba83c4755caa9a42aaa971d","compiler_version":"v0.55.0","strict":true}
 
-name: "NuGet Package Update"
+name: "Dependency Updater"
 "on":
   schedule:
   - cron: "0 8 * * 1"
@@ -46,7 +46,7 @@ permissions: {}
 concurrency:
   group: "gh-aw-${{ github.workflow }}"
 
-run-name: "NuGet Package Update"
+run-name: "Dependency Updater"
 
 jobs:
   activation:
@@ -72,7 +72,7 @@ jobs:
           GH_AW_INFO_VERSION: ""
           GH_AW_INFO_AGENT_VERSION: "latest"
           GH_AW_INFO_CLI_VERSION: "v0.55.0"
-          GH_AW_INFO_WORKFLOW_NAME: "NuGet Package Update"
+          GH_AW_INFO_WORKFLOW_NAME: "Dependency Updater"
           GH_AW_INFO_EXPERIMENTAL: "false"
           GH_AW_INFO_SUPPORTS_TOOLS_ALLOWLIST: "true"
           GH_AW_INFO_STAGED: "false"
@@ -1019,7 +1019,7 @@ jobs:
         if: always() && steps.detection_guard.outputs.run_detection == 'true'
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
-          WORKFLOW_NAME: "NuGet Package Update"
+          WORKFLOW_NAME: "Dependency Updater"
           WORKFLOW_DESCRIPTION: "Automatically updates NuGet packages across the solution, fixes any breaking changes introduced by the updates while preserving the public API surface, ensures the project builds and tests pass, then opens a pull request for review."
           HAS_PATCH: ${{ steps.collect_output.outputs.has_patch }}
         with:
@@ -1144,7 +1144,7 @@ jobs:
         env:
           GH_AW_AGENT_OUTPUT: ${{ env.GH_AW_AGENT_OUTPUT }}
           GH_AW_NOOP_MAX: "1"
-          GH_AW_WORKFLOW_NAME: "NuGet Package Update"
+          GH_AW_WORKFLOW_NAME: "Dependency Updater"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
@@ -1157,7 +1157,7 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           GH_AW_AGENT_OUTPUT: ${{ env.GH_AW_AGENT_OUTPUT }}
-          GH_AW_WORKFLOW_NAME: "NuGet Package Update"
+          GH_AW_WORKFLOW_NAME: "Dependency Updater"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
@@ -1170,7 +1170,7 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           GH_AW_AGENT_OUTPUT: ${{ env.GH_AW_AGENT_OUTPUT }}
-          GH_AW_WORKFLOW_NAME: "NuGet Package Update"
+          GH_AW_WORKFLOW_NAME: "Dependency Updater"
           GH_AW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           GH_AW_AGENT_CONCLUSION: ${{ needs.agent.result }}
           GH_AW_WORKFLOW_ID: "nuget-update"
@@ -1193,7 +1193,7 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           GH_AW_AGENT_OUTPUT: ${{ env.GH_AW_AGENT_OUTPUT }}
-          GH_AW_WORKFLOW_NAME: "NuGet Package Update"
+          GH_AW_WORKFLOW_NAME: "Dependency Updater"
           GH_AW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           GH_AW_AGENT_CONCLUSION: ${{ needs.agent.result }}
           GH_AW_NOOP_MESSAGE: ${{ steps.noop.outputs.noop_message }}
@@ -1210,7 +1210,7 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           GH_AW_AGENT_OUTPUT: ${{ env.GH_AW_AGENT_OUTPUT }}
-          GH_AW_WORKFLOW_NAME: "NuGet Package Update"
+          GH_AW_WORKFLOW_NAME: "Dependency Updater"
           GH_AW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
@@ -1236,7 +1236,7 @@ jobs:
       GH_AW_CALLER_WORKFLOW_ID: "${{ github.repository }}/nuget-update"
       GH_AW_ENGINE_ID: "copilot"
       GH_AW_WORKFLOW_ID: "nuget-update"
-      GH_AW_WORKFLOW_NAME: "NuGet Package Update"
+      GH_AW_WORKFLOW_NAME: "Dependency Updater"
     outputs:
       code_push_failure_count: ${{ steps.process_safe_outputs.outputs.code_push_failure_count }}
       code_push_failure_errors: ${{ steps.process_safe_outputs.outputs.code_push_failure_errors }}

--- a/.github/workflows/nuget-update.md
+++ b/.github/workflows/nuget-update.md
@@ -1,5 +1,5 @@
 ---
-name: NuGet Package Update
+name: Dependency Updater
 description: >
   Automatically updates NuGet packages across the solution, fixes any breaking
   changes introduced by the updates while preserving the public API surface,
@@ -54,7 +54,7 @@ safe-outputs:
 
 timeout-minutes: 30
 ---
-# NuGet Package Update
+# Dependency Updater
 
 You are a .NET dependency management assistant for the **Augustus** library
 (`Augustus.AI` on NuGet). Your job is to update NuGet packages, fix any breaking


### PR DESCRIPTION
## What changed

Renamed the agentic workflow from "NuGet Package Update" to "Dependency Updater" in both the workflow name and the markdown heading.

## Why

User requested a more general name.

## Test plan

- [ ] Verify workflow appears as "Dependency Updater" in the Actions tab after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)