### PR TITLE
fix: pass version via /p:Version in publish pipeline

### DIFF
--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -31,25 +31,14 @@ jobs:
           echo "VERSION=${VERSION}" >> $GITHUB_OUTPUT
           echo "Extracted version: ${VERSION}"
 
-      - name: Update version in project file
-        run: |
-          PROJECT_FILE="Augustus/Augustus/Augustus.csproj"
-          VERSION="${{ steps.version.outputs.VERSION }}"
-
-          # Update the Version property in the csproj file
-          sed -i "s/<Version>.*<\/Version>/<Version>${VERSION}<\/Version>/" "$PROJECT_FILE"
-
-          # Verify the change
-          grep -A0 "Version" "$PROJECT_FILE" | head -1
-
       - name: Restore dependencies
         run: dotnet restore Augustus/Augustus/Augustus.csproj
 
       - name: Build
-        run: dotnet build Augustus/Augustus/Augustus.csproj --configuration Release --no-restore
+        run: dotnet build Augustus/Augustus/Augustus.csproj --configuration Release --no-restore /p:Version=${{ steps.version.outputs.VERSION }}
 
       - name: Pack NuGet package
-        run: dotnet pack Augustus/Augustus/Augustus.csproj --configuration Release --no-build --output ./nupkg
+        run: dotnet pack Augustus/Augustus/Augustus.csproj --configuration Release --no-build --output ./nupkg /p:Version=${{ steps.version.outputs.VERSION }}
 
       - name: Publish to NuGet.org
         run: |


### PR DESCRIPTION
## Summary

- Fixes the publish pipeline producing `1.0.0` packages instead of the version from the release tag
- The `<Version>` tag was removed from csproj (now set by pipeline), but `publish-nuget.yml` was using `sed` to replace it — which matched nothing, causing dotnet to default to `1.0.0`
- Now passes version directly via `/p:Version=` on `dotnet build` and `dotnet pack` commands

## Context

Release v0.2.4 published `Augustus.AI.1.0.0.nupkg` instead of `Augustus.AI.0.2.4.nupkg`. The bad assets have been removed and the release converted to draft pending this fix.

## Test plan

- [ ] Merge this PR
- [ ] Re-publish the v0.2.4 draft release
- [ ] Verify the published package is `Augustus.AI.0.2.4.nupkg`

🤖 Generated with [Claude Code](https://claude.com/claude-code)