### PR TITLE
Normalize newlines in JSON string values for cross-platform cache keys

### DIFF
--- a/Augustus/Augustus.Tests/CacheKeyBodyNormalizerTests.cs
+++ b/Augustus/Augustus.Tests/CacheKeyBodyNormalizerTests.cs
@@ -188,6 +188,18 @@ public class CacheKeyBodyNormalizerTests
     }
 
     [Fact]
+    public void NormalizeForCacheKey_RootLevelString_CrLfIsNormalized()
+    {
+        // A bare JSON string (rare, but valid JSON) should also have newlines normalized
+        var body = Encoding.UTF8.GetBytes("\"hello\\r\\nworld\"");
+        var result = CacheKeyBodyNormalizer.NormalizeForCacheKey(body, Array.Empty<string>());
+        var json = Encoding.UTF8.GetString(result);
+
+        json.Should().NotContain("\\r");
+        json.Should().Contain("\\nworld");
+    }
+
+    [Fact]
     public void NormalizeForCacheKey_EmptyBody_ReturnsUnchanged()
     {
         var body = Array.Empty<byte>();

--- a/Augustus/Augustus/CacheKeyBodyNormalizer.cs
+++ b/Augustus/Augustus/CacheKeyBodyNormalizer.cs
@@ -49,7 +49,18 @@ internal static class CacheKeyBodyNormalizer
             // regardless of the platform that generated the request body. This is necessary
             // because StringBuilder.AppendLine(), TextWriter.WriteLine(), and similar APIs
             // use Environment.NewLine which is \r\n on Windows and \n on Linux.
-            NormalizeNewlines(canonical);
+            // For root-level JsonValue strings (unlikely in practice), create a replacement node
+            // since JsonValue has no portable in-place mutation before net9.
+            if (canonical is JsonValue rootVal
+                && rootVal.TryGetValue<string>(out var rootStr)
+                && rootStr.Contains('\r'))
+            {
+                canonical = JsonValue.Create(rootStr.ReplaceLineEndings("\n"));
+            }
+            else
+            {
+                NormalizeNewlines(canonical);
+            }
 
             if (propertyNames.Count > 0)
                 NormalizeNode(canonical, propertyNames);
@@ -189,10 +200,6 @@ internal static class CacheKeyBodyNormalizer
                     else if (child is JsonObject or JsonArray)
                         NormalizeNewlines(child!);
                 }
-                break;
-            case JsonValue val:
-                if (val.TryGetValue<string>(out var s) && s.Contains('\r'))
-                    val.SetValue(s.ReplaceLineEndings("\n"));
                 break;
         }
     }


### PR DESCRIPTION
## Problem

Cache files generated on Windows don't match the same logical requests on Linux (and vice versa), causing 100% cache misses in CI when running in cache-only mode.

**Root cause**: Application code uses `StringBuilder.AppendLine()`, `TextWriter.WriteLine()`, and similar APIs that use `Environment.NewLine` — which is `\r\n` on Windows and `\n` on Linux. These newline characters end up inside JSON string values in OpenAI request bodies (e.g., system prompt content):

```
Windows: {"messages":[{"content":"CONTEXT:\r\nFeature: Login\r\nAs a user"}]}
Linux:   {"messages":[{"content":"CONTEXT:\nFeature: Login\nAs a user"}]}
```

Augustus 0.6.0 already normalizes JSON **structure** (key sorting, relaxed escaping), but doesn't normalize **string value content** — so `\r\n` vs `\n` inside string values produces different SHA256 hashes → different cache keys → cache miss.

## Solution

Add a `NormalizeNewlines` pass in `CacheKeyBodyNormalizer.PrepareBodyForCacheKey()` that walks all JSON string values and replaces `\r\n` (and standalone `\r`) with `\n` using `string.ReplaceLineEndings("\n")`. This runs after `SortKeysRecursive` and before `NormalizeNode`.

The normalization pipeline is now:
1. Parse JSON
2. Sort keys recursively (0.6.0)
3. **Normalize newlines in string values** ← NEW
4. Replace dynamic content fields
5. Serialize with `UnsafeRelaxedJsonEscaping`
6. SHA256

## Tests

5 new tests covering:
- `\r\n` vs `\n` in string values produce identical normalized output
- `\r\n` vs `\n` produce identical cache keys via `CacheKeyComputer`
- Deeply nested string values are normalized
- Array string values are normalized
- Standalone `\r` (old Mac line endings) are normalized

All 500 existing tests continue to pass across net8.0, net9.0, and net10.0.

## Impact

This is a **cache-key-breaking change** — existing cache files generated with 0.6.0 that contain `\r\n` in string values will produce different hashes after this fix. Users will need to regenerate their cache files once. After regeneration, cache files will work identically on both Windows and Linux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)