### PR TITLE
docs: add package-specific NuGet READMEs for all five packages

### DIFF
--- a/Augustus/Augustus.AI/Augustus.AI.csproj
+++ b/Augustus/Augustus.AI/Augustus.AI.csproj
@@ -14,7 +14,12 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <InternalsVisibleTo>Augustus.AI.Tests</InternalsVisibleTo>
+    <PackageReadmeFile>PACKAGE_README.md</PackageReadmeFile>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="PACKAGE_README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Augustus\Augustus.csproj" />

--- a/Augustus/Augustus.AI/PACKAGE_README.md
+++ b/Augustus/Augustus.AI/PACKAGE_README.md
@@ -1,0 +1,121 @@
+# Augustus.AI
+
+OpenAI-powered extension for [Augustus](https://www.nuget.org/packages/Augustus). Generates realistic API responses using AI and supports proxying to real APIs with caching.
+
+[![NuGet](https://img.shields.io/nuget/v/Augustus.AI.svg)](https://www.nuget.org/packages/Augustus.AI)
+[![License](https://img.shields.io/badge/License-MIT-green.svg)](https://github.com/chrisjainsley/augustus/blob/master/LICENSE)
+
+Requires the [Augustus](https://www.nuget.org/packages/Augustus) core package (installed automatically as a dependency).
+
+## Quick Start
+
+### AI default handler for unmatched routes
+
+```csharp
+using Augustus.AI;
+using Augustus.Extensions;
+
+var simulator = this.CreateStripeSimulator(opt => opt.Port = 0);
+simulator.UseAI(new AIOptions
+{
+    OpenAIApiKey = Environment.GetEnvironmentVariable("OPENAI_API_KEY")!
+});
+
+// Static override — always served from this JSON
+simulator.ForGet("/v1/customers/cus_known")
+    .WithResponse(new { id = "cus_known", name = "John Doe" })
+    .Add();
+
+// Everything else handled by AI
+simulator.AddInstruction("Return realistic Stripe API responses");
+
+await simulator.StartAsync();
+var client = simulator.CreateClient();
+
+// Hits the static route
+var known = await client.GetStringAsync("/v1/customers/cus_known");
+
+// Falls through to AI
+var generated = await client.GetStringAsync("/v1/customers/cus_other");
+
+await simulator.StopAsync();
+```
+
+### Per-route AI
+
+```csharp
+simulator.ForGet("/v1/payments/{id}")
+    .UseAI(aiOptions, "Return a completed payment object")
+    .Add();
+
+simulator.ForPost("/v1/payments")
+    .WithResponse(new { id = "pay_static", status = "pending" })
+    .Add();
+```
+
+### Real API proxy
+
+Forward requests to an upstream API, cache responses, and replay on subsequent calls:
+
+```csharp
+var simulator = this.CreateAPISimulator("OpenAI Proxy");
+simulator.UseProxy(
+    new AIOptions
+    {
+        OpenAIApiKey = Environment.GetEnvironmentVariable("OPENAI_API_KEY")!
+    },
+    upstreamUrl: "https://api.openai.com"
+);
+await simulator.StartAsync();
+
+var client = simulator.CreateClient();
+// First call: forwarded to real API, response cached
+// Second call: served from cache instantly
+var response = await client.PostAsync("/v1/chat/completions", content);
+```
+
+## Key Features
+
+- **AI response generation** — generate realistic API responses via OpenAI for any unmatched route
+- **Per-route AI** — use `UseAI()` on individual routes with custom instructions
+- **Real API proxy** — forward to upstream APIs and cache responses for replay
+- **Azure OpenAI support** — use Azure-hosted models with `UseAzureOpenAI`
+- **Response caching** — AI and proxy responses cached to disk for fast, deterministic reruns
+- **Rate limit handling** — shared throttling, in-flight deduplication, exponential backoff with jitter
+- **Cache-only mode** — run in CI without an API key using pre-recorded responses
+
+## Configuration
+
+```csharp
+simulator.UseAI(new AIOptions
+{
+    OpenAIApiKey = "sk-...",              // Required (unless CacheOnly)
+    OpenAIModel = "gpt-4o-mini",         // Default model
+    OpenAIEndpoint = "",                  // Custom endpoint (optional)
+    UseAzureOpenAI = false,               // Use Azure OpenAI service
+    AzureDeploymentName = "",             // Required when UseAzureOpenAI = true
+    AzureApiVersion = "2024-06-01",       // Azure API version
+    MaxRetries = 5,                       // Retry attempts for transient failures
+    MaxConcurrentRequests = 10            // Process-wide concurrent OpenAI limit
+});
+```
+
+## Rate Limits and Efficiency
+
+- **Shared throttling** — all OpenAI calls in the process share one concurrency gate per API key/model combination
+- **In-flight deduplication** — concurrent requests with the same cache key share a single OpenAI completion
+- **Retries** — transient failures (429, 5xx) use exponential backoff with jitter, respecting `Retry-After` headers
+- **Tip** — for first-time cache generation, use low `MaxConcurrentRequests` (1-2) and run tests serially to minimize billed retries
+
+## Related Packages
+
+| Package | Purpose |
+|---------|---------|
+| [Augustus](https://www.nuget.org/packages/Augustus) | Core simulator — route matching, static responses, caching |
+| [Augustus.Stripe](https://www.nuget.org/packages/Augustus.Stripe) | Pre-built Stripe API defaults and fluent helpers |
+| [Augustus.GitHub](https://www.nuget.org/packages/Augustus.GitHub) | Pre-built GitHub API defaults and fluent helpers |
+| [Augustus.Reqnroll](https://www.nuget.org/packages/Augustus.Reqnroll) | Reqnroll (BDD) integration with per-scenario cache isolation |
+
+## Documentation
+
+Full documentation and examples: [github.com/chrisjainsley/augustus](https://github.com/chrisjainsley/augustus)

--- a/Augustus/Augustus.APIs.GitHub/Augustus.GitHub.csproj
+++ b/Augustus/Augustus.APIs.GitHub/Augustus.GitHub.csproj
@@ -13,7 +13,12 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <PackageReadmeFile>PACKAGE_README.md</PackageReadmeFile>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="PACKAGE_README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
 
   <ItemGroup>
     <InternalsVisibleTo Include="Augustus.GitHub.Tests" />

--- a/Augustus/Augustus.APIs.GitHub/PACKAGE_README.md
+++ b/Augustus/Augustus.APIs.GitHub/PACKAGE_README.md
@@ -1,0 +1,102 @@
+# Augustus.GitHub
+
+Pre-built GitHub REST API defaults and fluent helpers for [Augustus](https://www.nuget.org/packages/Augustus). Mock GitHub endpoints with realistic responses in a few lines of code.
+
+[![NuGet](https://img.shields.io/nuget/v/Augustus.GitHub.svg)](https://www.nuget.org/packages/Augustus.GitHub)
+[![License](https://img.shields.io/badge/License-MIT-green.svg)](https://github.com/chrisjainsley/augustus/blob/master/LICENSE)
+
+Requires the [Augustus](https://www.nuget.org/packages/Augustus) core package (installed automatically as a dependency).
+
+## Quick Start
+
+### Use all defaults
+
+Register every GitHub endpoint with realistic default responses in one call:
+
+```csharp
+using Augustus.APIs.GitHub;
+
+var mock = this.CreateGitHubMock(opt => opt.Port = 0);
+mock.UseAllDefaults();
+
+await mock.StartAsync();
+
+var client = mock.CreateClient();
+var response = await client.GetAsync("/repos/octocat/hello-world");
+// Returns a realistic GitHub repository object
+
+await mock.StopAsync();
+```
+
+### Configure specific endpoints
+
+```csharp
+var mock = this.CreateGitHubMock(opt => opt.Port = 0);
+
+// Use built-in defaults for specific resources
+mock.Repositories().Get().UseDefault();
+mock.PullRequests().List().UseDefault();
+mock.Issues().Create().UseDefault();
+
+// Override with custom responses
+mock.Users().Get().WithResponse(new
+{
+    login = "testuser",
+    id = 12345,
+    type = "User",
+    name = "Test User"
+});
+
+await mock.StartAsync();
+```
+
+### Use from a generic simulator
+
+```csharp
+using Augustus.Extensions;
+using Augustus.APIs.GitHub;
+
+var simulator = this.CreateAPISimulator("GitHub", opt => opt.Port = 0);
+simulator.GitHub().Repositories().Get().UseDefault();
+simulator.GitHub().PullRequests().List().UseDefault();
+
+await simulator.StartAsync();
+```
+
+## Key Features
+
+- **One-line setup** — `UseAllDefaults()` registers all GitHub endpoints with realistic responses
+- **Fluent resource builders** — type-safe API for configuring individual GitHub resources
+- **Realistic defaults** — built-in responses that match GitHub's actual REST API shape
+- **Custom overrides** — replace any default with inline JSON, objects, or file-based responses
+- **Error simulation** — return pre-configured GitHub error responses (404, 422, etc.)
+- **Latency simulation** — add realistic latency with `WithLatency(meanMs, stdDevMs)`
+
+## Supported Resources
+
+| Builder | Endpoints |
+|---------|-----------|
+| `Repositories()` | Get, ListForAuthenticatedUser, ListForUser, Create, Update, Delete |
+| `Issues()` | Get, List, Create, Update |
+| `PullRequests()` | Get, List, Create, Update |
+| `Commits()` | Get, List |
+| `Branches()` | Get, List |
+| `Releases()` | Get, List, Create |
+| `Actions()` | GetWorkflowRun, ListWorkflowRuns |
+| `Users()` | Get, GetAuthenticated |
+| `Organizations()` | Get, ListForAuthenticatedUser, ListForUser |
+| `GitRefs()` | Get, List, Create |
+| `Search()` | Repositories, Issues, Code |
+
+## Related Packages
+
+| Package | Purpose |
+|---------|---------|
+| [Augustus](https://www.nuget.org/packages/Augustus) | Core simulator — route matching, static responses, caching |
+| [Augustus.AI](https://www.nuget.org/packages/Augustus.AI) | AI-powered response generation and real-API proxy via OpenAI |
+| [Augustus.Stripe](https://www.nuget.org/packages/Augustus.Stripe) | Pre-built Stripe API defaults and fluent helpers |
+| [Augustus.Reqnroll](https://www.nuget.org/packages/Augustus.Reqnroll) | Reqnroll (BDD) integration with per-scenario cache isolation |
+
+## Documentation
+
+Full documentation and examples: [github.com/chrisjainsley/augustus](https://github.com/chrisjainsley/augustus)

--- a/Augustus/Augustus.APIs.Stripe/Augustus.Stripe.csproj
+++ b/Augustus/Augustus.APIs.Stripe/Augustus.Stripe.csproj
@@ -13,7 +13,12 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <PackageReadmeFile>PACKAGE_README.md</PackageReadmeFile>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="PACKAGE_README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
 
   <ItemGroup>
     <InternalsVisibleTo Include="Augustus.Stripe.Tests" />

--- a/Augustus/Augustus.APIs.Stripe/PACKAGE_README.md
+++ b/Augustus/Augustus.APIs.Stripe/PACKAGE_README.md
@@ -1,0 +1,122 @@
+# Augustus.Stripe
+
+Pre-built Stripe API defaults and fluent helpers for [Augustus](https://www.nuget.org/packages/Augustus). Mock Stripe endpoints with realistic responses in a few lines of code.
+
+[![NuGet](https://img.shields.io/nuget/v/Augustus.Stripe.svg)](https://www.nuget.org/packages/Augustus.Stripe)
+[![License](https://img.shields.io/badge/License-MIT-green.svg)](https://github.com/chrisjainsley/augustus/blob/master/LICENSE)
+
+Requires the [Augustus](https://www.nuget.org/packages/Augustus) core package (installed automatically as a dependency).
+
+## Quick Start
+
+### Use all defaults
+
+Register every Stripe endpoint with realistic default responses in one call:
+
+```csharp
+using Augustus.APIs.Stripe;
+
+var mock = this.CreateStripeMock(opt => opt.Port = 0);
+mock.UseAllDefaults();
+
+await mock.StartAsync();
+
+var client = mock.CreateClient();
+var response = await client.GetAsync("/v1/customers/cus_123");
+// Returns a realistic Stripe customer object
+
+await mock.StopAsync();
+```
+
+### Configure specific endpoints
+
+```csharp
+var mock = this.CreateStripeMock(opt => opt.Port = 0);
+
+// Use built-in defaults for specific resources
+mock.Customers().Get().UseDefault();
+mock.Customers().List().UseDefault();
+mock.PaymentIntents().Create().UseDefault();
+
+// Override with custom responses
+mock.Charges().Get().WithResponse(new
+{
+    id = "ch_custom",
+    amount = 5000,
+    currency = "usd",
+    status = "succeeded"
+});
+
+await mock.StartAsync();
+```
+
+### Use from a generic simulator
+
+```csharp
+using Augustus.Extensions;
+using Augustus.APIs.Stripe;
+
+var simulator = this.CreateAPISimulator("Stripe", opt => opt.Port = 0);
+simulator.Stripe().Customers().Get().UseDefault();
+simulator.Stripe().PaymentIntents().Create().UseDefault();
+
+await simulator.StartAsync();
+```
+
+## Key Features
+
+- **One-line setup** — `UseAllDefaults()` registers all Stripe endpoints with realistic responses
+- **Fluent resource builders** — type-safe API for configuring individual Stripe resources
+- **Realistic defaults** — built-in responses that match Stripe's actual API shape
+- **Custom overrides** — replace any default with inline JSON, objects, or file-based responses
+- **Error simulation** — return pre-configured Stripe error responses
+- **Webhook events** — simulate Stripe webhook delivery with signing secrets
+- **Latency simulation** — add realistic latency with `WithLatency(meanMs, stdDevMs)`
+
+## Supported Resources
+
+| Builder | Endpoints |
+|---------|-----------|
+| `Customers()` | Get, List, Create, Update, Delete |
+| `Charges()` | Get, List, Create, Capture |
+| `PaymentIntents()` | Get, List, Create, Confirm, Cancel |
+| `PaymentMethods()` | Get, List, Create, Update, Attach, Detach |
+| `Subscriptions()` | Get, List, Create, Update, Cancel |
+| `Invoices()` | Get, List, Create, Update, Delete, Finalize, Pay, Void |
+| `InvoiceItems()` | Get, List, Create, Update, Delete |
+| `Refunds()` | Get, List, Create, Update |
+| `Disputes()` | Get, List |
+| `Products()` | Get, List, Create |
+| `Prices()` | Get, List, Create |
+| `Coupons()` | Get, List, Create, Delete |
+| `Payouts()` | Get, List, Create |
+| `Balance()` | Get |
+| `BalanceTransactions()` | Get, List |
+| `Events()` | Get, List |
+| `Tokens()` | Create |
+| `SetupIntents()` | Get, List, Create, Confirm, Cancel |
+
+## Webhook Simulation
+
+```csharp
+var mock = this.CreateStripeMock(opt => opt.Port = 0);
+mock.UseAllDefaults();
+mock.WithWebhook("https://myapp.test/webhooks/stripe", signingSecret: "whsec_test123")
+    .OnRequest(HttpMethod.Post, "/v1/charges")
+        .FireWebhookEvent("charge.created")
+        .WithPayload(new { type = "charge.created", data = new { id = "ch_123" } })
+        .Add();
+```
+
+## Related Packages
+
+| Package | Purpose |
+|---------|---------|
+| [Augustus](https://www.nuget.org/packages/Augustus) | Core simulator — route matching, static responses, caching |
+| [Augustus.AI](https://www.nuget.org/packages/Augustus.AI) | AI-powered response generation and real-API proxy via OpenAI |
+| [Augustus.GitHub](https://www.nuget.org/packages/Augustus.GitHub) | Pre-built GitHub API defaults and fluent helpers |
+| [Augustus.Reqnroll](https://www.nuget.org/packages/Augustus.Reqnroll) | Reqnroll (BDD) integration with per-scenario cache isolation |
+
+## Documentation
+
+Full documentation and examples: [github.com/chrisjainsley/augustus](https://github.com/chrisjainsley/augustus)

--- a/Augustus/Augustus.Reqnroll/Augustus.Reqnroll.csproj
+++ b/Augustus/Augustus.Reqnroll/Augustus.Reqnroll.csproj
@@ -10,14 +10,14 @@
     <PackageTags>testing;mocking;ai;openai;api;simulator;reqnroll;specflow;bdd</PackageTags>
     <RepositoryUrl>https://github.com/chrisjainsley/augustus</RepositoryUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageReadmeFile>PACKAGE_README.md</PackageReadmeFile>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
+    <None Include="PACKAGE_README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Augustus/Augustus.Reqnroll/PACKAGE_README.md
+++ b/Augustus/Augustus.Reqnroll/PACKAGE_README.md
@@ -12,7 +12,6 @@ Requires the [Augustus](https://www.nuget.org/packages/Augustus) core package (i
 Register your simulator in a Reqnroll `[Binding]` hook. Augustus.Reqnroll automatically intercepts the scenario lifecycle to route cached responses into per-scenario subdirectories next to your feature files.
 
 ```csharp
-using Augustus.AI;
 using Augustus.Extensions;
 using Augustus.Reqnroll;
 using Reqnroll;
@@ -26,11 +25,6 @@ public class Hooks
     public static async Task BeforeTestRun()
     {
         _simulator = new Hooks().CreateStripeSimulator();
-        _simulator.UseAI(new AIOptions
-        {
-            OpenAIApiKey = Environment.GetEnvironmentVariable("OPENAI_API_KEY")!
-        });
-        _simulator.AddInstruction("Return realistic Stripe API responses");
 
         AugustusReqnrollContext.Register(_simulator);
         await _simulator.StartAsync();
@@ -40,9 +34,17 @@ public class Hooks
     public static async Task AfterTestRun()
     {
         AugustusReqnrollContext.Clear();
+        if (_simulator is not null)
+        {
+            await _simulator.StopAsync();
+            await _simulator.DisposeAsync();
+            _simulator = null;
+        }
     }
 }
 ```
+
+To use AI-generated responses, also install [Augustus.AI](https://www.nuget.org/packages/Augustus.AI) and call `_simulator.UseAI(...)` before `StartAsync`.
 
 ## Key Features
 

--- a/Augustus/Augustus.Reqnroll/PACKAGE_README.md
+++ b/Augustus/Augustus.Reqnroll/PACKAGE_README.md
@@ -1,0 +1,93 @@
+# Augustus.Reqnroll
+
+[Reqnroll](https://reqnroll.net/) (BDD/Gherkin) integration for [Augustus](https://www.nuget.org/packages/Augustus). Automatically organizes mock caches by scenario and places them next to your feature files.
+
+[![NuGet](https://img.shields.io/nuget/v/Augustus.Reqnroll.svg)](https://www.nuget.org/packages/Augustus.Reqnroll)
+[![License](https://img.shields.io/badge/License-MIT-green.svg)](https://github.com/chrisjainsley/augustus/blob/master/LICENSE)
+
+Requires the [Augustus](https://www.nuget.org/packages/Augustus) core package (installed automatically as a dependency).
+
+## Quick Start
+
+Register your simulator in a Reqnroll `[Binding]` hook. Augustus.Reqnroll automatically intercepts the scenario lifecycle to route cached responses into per-scenario subdirectories next to your feature files.
+
+```csharp
+using Augustus.AI;
+using Augustus.Extensions;
+using Augustus.Reqnroll;
+using Reqnroll;
+
+[Binding]
+public class Hooks
+{
+    private static APISimulator? _simulator;
+
+    [BeforeTestRun]
+    public static async Task BeforeTestRun()
+    {
+        _simulator = new Hooks().CreateStripeSimulator();
+        _simulator.UseAI(new AIOptions
+        {
+            OpenAIApiKey = Environment.GetEnvironmentVariable("OPENAI_API_KEY")!
+        });
+        _simulator.AddInstruction("Return realistic Stripe API responses");
+
+        AugustusReqnrollContext.Register(_simulator);
+        await _simulator.StartAsync();
+    }
+
+    [AfterTestRun]
+    public static async Task AfterTestRun()
+    {
+        AugustusReqnrollContext.Clear();
+    }
+}
+```
+
+## Key Features
+
+- **Per-scenario cache isolation** — each scenario gets its own cache directory, preventing collisions in parallel runs
+- **Automatic cache placement** — mock files are stored next to your `.feature` files in a `__mocks__` directory
+- **Zero configuration** — register your simulator once and the Reqnroll hooks handle the rest
+- **Works with all response strategies** — static, file-based, AI-generated, or proxy responses all cache correctly
+
+## Cache Directory Structure
+
+Cached responses are organized automatically by API name and scenario:
+
+```
+Features/
+  __mocks__/
+    Stripe/
+      Scenario_Name_1/
+        {hash}.json
+      Scenario_Name_2/
+        {hash}.json
+  MyFeature.feature
+```
+
+## API
+
+```csharp
+// Register a simulator (call in [BeforeTestRun])
+AugustusReqnrollContext.Register(simulator);
+
+// Retrieve a registered simulator by index
+var sim = AugustusReqnrollContext.GetRegisteredSimulator(0);
+
+// Clean up all registered simulators (call in [AfterTestRun])
+AugustusReqnrollContext.Clear();
+```
+
+## Related Packages
+
+| Package | Purpose |
+|---------|---------|
+| [Augustus](https://www.nuget.org/packages/Augustus) | Core simulator — route matching, static responses, caching |
+| [Augustus.AI](https://www.nuget.org/packages/Augustus.AI) | AI-powered response generation and real-API proxy via OpenAI |
+| [Augustus.Stripe](https://www.nuget.org/packages/Augustus.Stripe) | Pre-built Stripe API defaults and fluent helpers |
+| [Augustus.GitHub](https://www.nuget.org/packages/Augustus.GitHub) | Pre-built GitHub API defaults and fluent helpers |
+
+## Documentation
+
+Full documentation and examples: [github.com/chrisjainsley/augustus](https://github.com/chrisjainsley/augustus)

--- a/Augustus/Augustus/Augustus.csproj
+++ b/Augustus/Augustus/Augustus.csproj
@@ -12,14 +12,14 @@
     <PackageTags>testing;mocking;api;simulator;xunit;nunit;mstest</PackageTags>
     <RepositoryUrl>https://github.com/chrisjainsley/augustus</RepositoryUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageReadmeFile>PACKAGE_README.md</PackageReadmeFile>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
+    <None Include="PACKAGE_README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Augustus/Augustus/PACKAGE_README.md
+++ b/Augustus/Augustus/PACKAGE_README.md
@@ -1,0 +1,128 @@
+# Augustus
+
+A lightweight API simulator for .NET. Serve static JSON, load from files, or plug in custom response strategies — all from a local web server running inside your tests.
+
+[![NuGet](https://img.shields.io/nuget/v/Augustus.svg)](https://www.nuget.org/packages/Augustus)
+[![License](https://img.shields.io/badge/License-MIT-green.svg)](https://github.com/chrisjainsley/augustus/blob/master/LICENSE)
+
+## Quick Start
+
+```csharp
+using Augustus.Extensions;
+
+public class ApiTests
+{
+    [Fact]
+    public async Task Should_Return_Customer_Data()
+    {
+        var simulator = this.CreateAPISimulator("MyAPI")
+            .ForGet("/v1/customers/{id}")
+                .WithJsonFile("./mocks/customer.json")
+                .Add()
+            .ForPost("/v1/charges")
+                .WithResponse(new { id = "ch_123", amount = 2000, currency = "usd", status = "succeeded" })
+                .Add();
+
+        await simulator.StartAsync();
+
+        var client = simulator.CreateClient();
+        var response = await client.GetAsync("/v1/customers/cus_123");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        await simulator.StopAsync();
+    }
+}
+```
+
+## Key Features
+
+- **Route matching** with path parameters (`/v1/customers/{id}`) and wildcard support
+- **Static JSON responses** — inline objects or string literals
+- **File-based responses** — serve JSON from disk with `WithJsonFile()`
+- **Custom strategies** — implement `IResponseStrategy` for full control
+- **Request verification** — assert requests were received with `Verify()`
+- **Webhook delivery** — simulate outbound webhook events triggered by incoming requests
+- **Response caching** — cache and replay responses for fast, deterministic tests
+- **Cache-only mode** — run in CI without network access using pre-recorded mocks
+- **Auto port assignment** — use `Port = 0` to avoid conflicts in parallel test runs
+- **Framework agnostic** — works with xUnit, NUnit, MSTest, or any test runner
+
+## Response Strategies
+
+```csharp
+// Static JSON
+simulator.ForGet("/api/health")
+    .WithResponse(new { status = "ok" })
+    .WithStatusCode(200)
+    .Add();
+
+// JSON file
+simulator.ForGet("/v1/customers/{id}")
+    .WithJsonFile("./mocks/customer.json")
+    .Add();
+
+// Custom strategy
+simulator.ForPost("/api/echo")
+    .WithStrategy(new MyCustomStrategy())
+    .Add();
+```
+
+## Request Verification
+
+```csharp
+await simulator.StartAsync();
+var client = simulator.CreateClient();
+await client.PostAsync("/v1/charges", content);
+
+// Assert the request was received
+simulator.Verify(r => r.Path == "/v1/charges" && r.Method == HttpMethod.Post)
+    .WasCalledOnce();
+
+simulator.Verify(r => r.Path == "/v1/refunds")
+    .WasNeverCalled();
+```
+
+## Webhook Delivery
+
+```csharp
+var simulator = this.CreateAPISimulator("Stripe")
+    .WithWebhook("https://myapp.test/webhooks/stripe")
+    .OnRequest(HttpMethod.Post, "/v1/charges")
+        .FireWebhookEvent("charge.created")
+        .WithPayload(new { type = "charge.created", data = new { id = "ch_123" } })
+        .WithDelay(TimeSpan.FromMilliseconds(100))
+        .Add();
+```
+
+## Configuration
+
+```csharp
+var simulator = this.CreateAPISimulator("MyAPI", options =>
+{
+    options.Port = 0;                        // 0 = auto-assign (default: 9001)
+    options.EnableCaching = true;            // Cache responses (default: true)
+    options.CacheFolderPath = "./mocks";     // Cache location (default: ./mocks)
+    options.CacheOnly = false;               // Serve only from cache (default: false)
+    options.AutoRemoveStaleCache = true;     // Clean up unused cache files (default: true)
+});
+```
+
+## Route Resolution Order
+
+1. **Route with strategy** — matched route executes its configured `IResponseStrategy`
+2. **Default handler** — falls through to AI or proxy handler (if installed via Augustus.AI)
+3. **No match** — returns HTTP 404 JSON error
+
+## Related Packages
+
+| Package | Purpose |
+|---------|---------|
+| [Augustus.AI](https://www.nuget.org/packages/Augustus.AI) | AI-powered response generation and real-API proxy via OpenAI |
+| [Augustus.Stripe](https://www.nuget.org/packages/Augustus.Stripe) | Pre-built Stripe API defaults and fluent helpers |
+| [Augustus.GitHub](https://www.nuget.org/packages/Augustus.GitHub) | Pre-built GitHub API defaults and fluent helpers |
+| [Augustus.Reqnroll](https://www.nuget.org/packages/Augustus.Reqnroll) | Reqnroll (BDD) integration with per-scenario cache isolation |
+
+## Documentation
+
+Full documentation and examples: [github.com/chrisjainsley/augustus](https://github.com/chrisjainsley/augustus)

--- a/Augustus/Augustus/PACKAGE_README.md
+++ b/Augustus/Augustus/PACKAGE_README.md
@@ -102,7 +102,7 @@ var simulator = this.CreateAPISimulator("MyAPI", options =>
 {
     options.Port = 0;                        // 0 = auto-assign (default: 9001)
     options.EnableCaching = true;            // Cache responses (default: true)
-    options.CacheFolderPath = "./mocks";     // Cache location (default: ./mocks)
+    options.CacheFolderPath = "./mocks";     // Cache location (default: __mocks__/<TestClass>/<ApiName> via this.CreateAPISimulator; ./mocks via constructor)
     options.CacheOnly = false;               // Serve only from cache (default: false)
     options.AutoRemoveStaleCache = true;     // Clean up unused cache files (default: true)
 });


### PR DESCRIPTION
## Summary

- Each of the five NuGet packages now has a focused `PACKAGE_README.md` covering its own quick-start, key features, configuration, and links to sibling packages
- Previously Augustus and Augustus.Reqnroll shared the monolithic root README, while Augustus.AI, Augustus.Stripe, and Augustus.GitHub had no readme at all on nuget.org
- All five `.csproj` files updated to reference their local `PACKAGE_README.md` via `PackageReadmeFile` and `<None Include>` pack entries

## Test plan

- [x] `dotnet build Augustus/Augustus.sln` — 0 errors
- [x] `dotnet test Augustus/Augustus.sln -f net10.0` — 360 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)