### PR TITLE
feat: Optimize AI response handling in non-CI mode

### DIFF
--- a/Augustus/Augustus.AI/AIDefaultHandler.cs
+++ b/Augustus/Augustus.AI/AIDefaultHandler.cs
@@ -118,6 +118,8 @@ internal class AIDefaultHandler : IRequestHandler
             // OpenAI prompt token usage.
             var curlRequest = await Augustus.HttpRequestExtensions.ToCurlCommandAsync(
                 httpContext.Request, HttpRequestExtensions.DefaultAISkipHeaders).ConfigureAwait(false);
+            // Sanitize any residual sensitive values (query params, body tokens) before forwarding to OpenAI.
+            curlRequest = SensitiveDataSanitizer.SanitizeSensitiveValues(curlRequest);
 
             List<ChatMessage> messages = new List<ChatMessage>
             {

--- a/Augustus/Augustus.AI/AIDefaultHandler.cs
+++ b/Augustus/Augustus.AI/AIDefaultHandler.cs
@@ -53,8 +53,6 @@ internal class AIDefaultHandler : IRequestHandler
         {
             var bodyBytes = await httpContext.Request.ReadBodyBytesAsync(cancellationToken).ConfigureAwait(false);
 
-            var curlRequest = await Augustus.HttpRequestExtensions.ToCurlCommandAsync(httpContext.Request).ConfigureAwait(false);
-
             var instructions = instructionsContainer.GetInstructionsForRequest(
                 httpContext.Request.Path.Value ?? "/",
                 httpContext.Request.Method);
@@ -70,11 +68,14 @@ internal class AIDefaultHandler : IRequestHandler
 
             if (options.EnableCaching)
             {
-                var cachedResponse = await fileManager.ReadCachedResponseAsync(requestHash).ConfigureAwait(false);
-                if (!string.IsNullOrEmpty(cachedResponse))
+                var cachedEntry = await fileManager.ReadCachedEntryAsync(requestHash).ConfigureAwait(false);
+                if (cachedEntry?.Response is { Length: > 0 } cachedResponse)
                 {
-                    cachedResponse = ChatCompletionResponseNormalizer.NormalizeIfChatCompletion(
-                        cachedResponse, httpContext.Request.Path.Value ?? "/");
+                    if (!cachedEntry.Normalized)
+                    {
+                        cachedResponse = ChatCompletionResponseNormalizer.NormalizeIfChatCompletion(
+                            cachedResponse, httpContext.Request.Path.Value ?? "/");
+                    }
                     httpContext.Response.ContentType = "application/json";
                     await httpContext.Response.WriteAsync(cachedResponse, cancellationToken);
                     return;
@@ -112,12 +113,17 @@ internal class AIDefaultHandler : IRequestHandler
                 return;
             }
 
-            List<ChatMessage> messages = new List<ChatMessage>();
-            foreach (var instruction in instructions)
+            // Defer curl command generation until after cache check — avoids re-reading the body stream,
+            // iterating headers, and string building on cache hits. Filter noisy headers to reduce
+            // OpenAI prompt token usage.
+            var curlRequest = await Augustus.HttpRequestExtensions.ToCurlCommandAsync(
+                httpContext.Request, HttpRequestExtensions.DefaultAISkipHeaders).ConfigureAwait(false);
+
+            List<ChatMessage> messages = new List<ChatMessage>
             {
-                messages.Add(ChatMessage.CreateSystemMessage(instruction));
-            }
-            messages.Add(ChatMessage.CreateUserMessage(curlRequest));
+                ChatMessage.CreateSystemMessage(string.Join("\n\n", instructions)),
+                ChatMessage.CreateUserMessage(curlRequest)
+            };
 
             var chatOptions = AIResponseFormatting.CreateJsonObjectChatOptions();
 
@@ -148,7 +154,7 @@ internal class AIDefaultHandler : IRequestHandler
 
             if (options.EnableCaching)
             {
-                _cacheWriter.Enqueue(() => fileManager.CacheResponseAsync(requestHash, responseContent, curlRequest, instructions));
+                _cacheWriter.Enqueue(() => fileManager.CacheResponseAsync(requestHash, responseContent, curlRequest, instructions, normalized: true));
             }
         }
         catch (Exception ex) when (ex is not ArgumentException && ex is not InvalidOperationException)

--- a/Augustus/Augustus.AI/AIResponseFormatting.cs
+++ b/Augustus/Augustus.AI/AIResponseFormatting.cs
@@ -8,7 +8,8 @@ internal static class AIResponseFormatting
     {
         return new ChatCompletionOptions
         {
-            ResponseFormat = ChatResponseFormat.CreateJsonObjectFormat()
+            ResponseFormat = ChatResponseFormat.CreateJsonObjectFormat(),
+            Temperature = 0f
         };
     }
 

--- a/Augustus/Augustus.AI/AIResponseStrategy.cs
+++ b/Augustus/Augustus.AI/AIResponseStrategy.cs
@@ -103,7 +103,6 @@ public sealed class AIResponseStrategy : IResponseStrategy, IDisposable, IAsyncD
         try
         {
             var bodyBytes = await httpContext.Request.ReadBodyBytesAsync(cancellationToken).ConfigureAwait(false);
-            var curlRequest = await httpContext.Request.ToCurlCommandAsync().ConfigureAwait(false);
 
             var path = httpContext.Request.Path.Value ?? "/";
             var requestHash = CacheKeyComputer.ComputeCacheKey(
@@ -115,18 +114,27 @@ public sealed class AIResponseStrategy : IResponseStrategy, IDisposable, IAsyncD
                 instructions,
                 mergedDynamicFields);
 
+            // Defer curl command generation until after primary cache check — avoids re-reading the
+            // body stream, iterating headers, and string building on cache hits.
+            string? curlRequest = null;
+
             if (simOptions.EnableCaching && options.EnableCaching)
             {
-                var cachedResponse = await fileManager.ReadCachedResponseAsync(requestHash).ConfigureAwait(false);
-                if (string.IsNullOrEmpty(cachedResponse))
+                var cachedEntry = await fileManager.ReadCachedEntryAsync(requestHash).ConfigureAwait(false);
+                if (cachedEntry?.Response is not { Length: > 0 })
                 {
+                    // Legacy lookup needs the curl command; generate it on primary cache miss only.
+                    curlRequest = await httpContext.Request.ToCurlCommandAsync(HttpRequestExtensions.DefaultAISkipHeaders).ConfigureAwait(false);
                     var legacyHash = CacheManager.GenerateLegacyCurlBasedCacheKey(curlRequest, instructions);
-                    cachedResponse = await fileManager.ReadCachedResponseAsync(legacyHash).ConfigureAwait(false);
+                    cachedEntry = await fileManager.ReadCachedEntryAsync(legacyHash).ConfigureAwait(false);
                 }
 
-                if (!string.IsNullOrEmpty(cachedResponse))
+                if (cachedEntry?.Response is { Length: > 0 } cachedResponse)
                 {
-                    cachedResponse = ChatCompletionResponseNormalizer.NormalizeIfChatCompletion(cachedResponse, path);
+                    if (!cachedEntry.Normalized)
+                    {
+                        cachedResponse = ChatCompletionResponseNormalizer.NormalizeIfChatCompletion(cachedResponse, path);
+                    }
                     httpContext.Response.ContentType = "application/json";
                     await httpContext.Response.WriteAsync(cachedResponse, cancellationToken).ConfigureAwait(false);
                     return;
@@ -172,13 +180,14 @@ public sealed class AIResponseStrategy : IResponseStrategy, IDisposable, IAsyncD
                 return;
             }
 
-            List<ChatMessage> messages = new();
-            foreach (var instruction in instructions)
-            {
-                messages.Add(ChatMessage.CreateSystemMessage(instruction));
-            }
+            // Generate curl command if not already resolved during legacy cache lookup.
+            curlRequest ??= await httpContext.Request.ToCurlCommandAsync(HttpRequestExtensions.DefaultAISkipHeaders).ConfigureAwait(false);
 
-            messages.Add(ChatMessage.CreateUserMessage(curlRequest));
+            List<ChatMessage> messages = new()
+            {
+                ChatMessage.CreateSystemMessage(string.Join("\n\n", instructions)),
+                ChatMessage.CreateUserMessage(curlRequest)
+            };
 
             var chatOptions = AIResponseFormatting.CreateJsonObjectChatOptions();
             var chatResults = await requestHandler
@@ -208,7 +217,7 @@ public sealed class AIResponseStrategy : IResponseStrategy, IDisposable, IAsyncD
             {
                 try
                 {
-                    await fileManager.CacheResponseAsync(requestHash, responseContent, curlRequest, instructions).ConfigureAwait(false);
+                    await fileManager.CacheResponseAsync(requestHash, responseContent, curlRequest, instructions, normalized: true).ConfigureAwait(false);
                 }
                 catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
                 {

--- a/Augustus/Augustus.AI/AIResponseStrategy.cs
+++ b/Augustus/Augustus.AI/AIResponseStrategy.cs
@@ -123,9 +123,10 @@ public sealed class AIResponseStrategy : IResponseStrategy, IDisposable, IAsyncD
                 var cachedEntry = await fileManager.ReadCachedEntryAsync(requestHash).ConfigureAwait(false);
                 if (cachedEntry?.Response is not { Length: > 0 })
                 {
-                    // Legacy lookup needs the curl command; generate it on primary cache miss only.
-                    curlRequest = await httpContext.Request.ToCurlCommandAsync(HttpRequestExtensions.DefaultAISkipHeaders).ConfigureAwait(false);
-                    var legacyHash = CacheManager.GenerateLegacyCurlBasedCacheKey(curlRequest, instructions);
+                    // Legacy cache files were keyed on unfiltered cURL — use the original (no-skip-headers)
+                    // overload so existing entries remain discoverable after DefaultAISkipHeaders was introduced.
+                    var legacyCurl = await httpContext.Request.ToCurlCommandAsync().ConfigureAwait(false);
+                    var legacyHash = CacheManager.GenerateLegacyCurlBasedCacheKey(legacyCurl, instructions);
                     cachedEntry = await fileManager.ReadCachedEntryAsync(legacyHash).ConfigureAwait(false);
                 }
 
@@ -182,6 +183,8 @@ public sealed class AIResponseStrategy : IResponseStrategy, IDisposable, IAsyncD
 
             // Generate curl command if not already resolved during legacy cache lookup.
             curlRequest ??= await httpContext.Request.ToCurlCommandAsync(HttpRequestExtensions.DefaultAISkipHeaders).ConfigureAwait(false);
+            // Sanitize any residual sensitive values (query params, body tokens) before forwarding to OpenAI.
+            curlRequest = SensitiveDataSanitizer.SanitizeSensitiveValues(curlRequest);
 
             List<ChatMessage> messages = new()
             {

--- a/Augustus/Augustus.AI/CacheManager.cs
+++ b/Augustus/Augustus.AI/CacheManager.cs
@@ -23,7 +23,10 @@ internal class CacheManager
         }
     }
 
-    public async Task CacheResponseAsync(string requestHash, string response, string originalRequest, List<string> instructions)
+    public Task CacheResponseAsync(string requestHash, string response, string originalRequest, List<string> instructions)
+        => CacheResponseAsync(requestHash, response, originalRequest, instructions, normalized: false);
+
+    public async Task CacheResponseAsync(string requestHash, string response, string originalRequest, List<string> instructions, bool normalized)
     {
         var cacheEntry = new CacheEntry
         {
@@ -31,7 +34,8 @@ internal class CacheManager
             Response = response,
             OriginalRequest = originalRequest,
             Instructions = instructions,
-            Timestamp = DateTime.UtcNow
+            Timestamp = DateTime.UtcNow,
+            Normalized = normalized
         };
 
         var json = JsonSerializer.Serialize(cacheEntry, new JsonSerializerOptions { WriteIndented = true });
@@ -105,4 +109,5 @@ internal class CacheEntry
     public string OriginalRequest { get; set; } = string.Empty;
     public List<string> Instructions { get; set; } = new();
     public DateTime Timestamp { get; set; }
+    public bool Normalized { get; set; }
 }

--- a/Augustus/Augustus.Tests/FileManagerTests.cs
+++ b/Augustus/Augustus.Tests/FileManagerTests.cs
@@ -161,6 +161,84 @@ public class FileManagerTests
     }
 
     [Fact]
+    public async Task ReadCachedEntryAsync_NormalizedTrue_RoundTripsThoughDisk()
+    {
+        var cachePath = Path.Combine(Path.GetTempPath(), $"augustus-cache-tests-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(cachePath);
+
+        try
+        {
+            var fileManager = new APISimulator.FileManager(cachePath);
+            const string hash = "NORM_TRUE";
+
+            await fileManager.CacheResponseAsync(hash, "{\"ok\":true}", "curl ...", new List<string> { "inst" }, normalized: true);
+            var entry = await fileManager.ReadCachedEntryAsync(hash);
+
+            entry.Should().NotBeNull();
+            entry!.Normalized.Should().BeTrue();
+            entry.Response.Should().Be("{\"ok\":true}");
+        }
+        finally
+        {
+            if (Directory.Exists(cachePath))
+                Directory.Delete(cachePath, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task ReadCachedEntryAsync_DefaultNormalized_ReturnsFalse()
+    {
+        var cachePath = Path.Combine(Path.GetTempPath(), $"augustus-cache-tests-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(cachePath);
+
+        try
+        {
+            var fileManager = new APISimulator.FileManager(cachePath);
+            const string hash = "NORM_DEFAULT";
+
+            // Default overload omits normalized: true, so Normalized should be false
+            await fileManager.CacheResponseAsync(hash, "{\"ok\":true}", "curl ...", new List<string> { "inst" });
+            var entry = await fileManager.ReadCachedEntryAsync(hash);
+
+            entry.Should().NotBeNull();
+            entry!.Normalized.Should().BeFalse();
+        }
+        finally
+        {
+            if (Directory.Exists(cachePath))
+                Directory.Delete(cachePath, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task ReadCachedEntryAsync_LegacyFileWithoutNormalizedField_DefaultsToFalse()
+    {
+        var cachePath = Path.Combine(Path.GetTempPath(), $"augustus-cache-tests-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(cachePath);
+
+        try
+        {
+            var fileManager = new APISimulator.FileManager(cachePath);
+            const string hash = "LEGACY_NORM";
+
+            // Simulate a pre-existing cache file that predates the Normalized field
+            var legacyJson = "{\"RequestHash\":\"LEGACY_NORM\",\"Response\":\"{\\\"ok\\\":true}\",\"OriginalRequest\":\"curl ...\",\"Instructions\":[],\"Timestamp\":\"2024-01-01T00:00:00Z\"}";
+            await File.WriteAllTextAsync(Path.Combine(cachePath, $"{hash}.json"), legacyJson);
+
+            var entry = await fileManager.ReadCachedEntryAsync(hash);
+
+            entry.Should().NotBeNull();
+            entry!.Normalized.Should().BeFalse();
+            entry.Response.Should().Be("{\"ok\":true}");
+        }
+        finally
+        {
+            if (Directory.Exists(cachePath))
+                Directory.Delete(cachePath, recursive: true);
+        }
+    }
+
+    [Fact]
     public void RemoveStaleEntries_ShouldHandleNonexistentFolder()
     {
         var cachePath = Path.Combine(Path.GetTempPath(), $"augustus-cache-tests-{Guid.NewGuid():N}");

--- a/Augustus/Augustus.Tests/HttpRequestExtensionsTests.cs
+++ b/Augustus/Augustus.Tests/HttpRequestExtensionsTests.cs
@@ -122,6 +122,47 @@ public class HttpRequestExtensionsTests
         CountOccurrences(curl, "https://").Should().Be(1);
     }
 
+    [Fact]
+    public async Task ToCurlCommandAsync_WithSkipHeaders_OmitsSpecifiedHeaders()
+    {
+        var context = new DefaultHttpContext();
+        var request = context.Request;
+        request.Method = HttpMethods.Get;
+        request.Scheme = "https";
+        request.Host = new HostString("api.example.com");
+        request.Path = "/v1/resources";
+        request.Headers.Append("X-Trace-Id", "keep-me");
+        request.Headers.Append("Authorization", "Bearer secret-token");
+        request.Headers.Append("Content-Length", "0");
+
+        var skipHeaders = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "Authorization", "Content-Length" };
+        var curl = await request.ToCurlCommandAsync(skipHeaders);
+
+        curl.Should().Contain("-H \"X-Trace-Id: keep-me\"");
+        curl.Should().NotContain("Authorization");
+        curl.Should().NotContain("Content-Length");
+    }
+
+    [Fact]
+    public async Task ToCurlCommandAsync_DefaultAISkipHeaders_MatchingIsCaseInsensitive()
+    {
+        var context = new DefaultHttpContext();
+        var request = context.Request;
+        request.Method = HttpMethods.Get;
+        request.Scheme = "https";
+        request.Host = new HostString("api.example.com");
+        request.Path = "/v1/resources";
+        request.Headers.Append("content-length", "42");
+        request.Headers.Append("AUTHORIZATION", "Bearer tok");
+        request.Headers.Append("X-Custom", "keep-me");
+
+        var curl = await request.ToCurlCommandAsync(HttpRequestExtensions.DefaultAISkipHeaders);
+
+        curl.Should().NotContain("content-length");
+        curl.Should().NotContain("AUTHORIZATION");
+        curl.Should().Contain("-H \"X-Custom: keep-me\"");
+    }
+
     private static int CountOccurrences(string value, string segment)
     {
         var count = 0;

--- a/Augustus/Augustus.Tests/PublicApiTests.ApprovePublicApi.verified.txt
+++ b/Augustus/Augustus.Tests/PublicApiTests.ApprovePublicApi.verified.txt
@@ -67,6 +67,7 @@ namespace Augustus
     {
         public static System.Threading.Tasks.Task<byte[]> ReadBodyBytesAsync(this Microsoft.AspNetCore.Http.HttpRequest request, System.Threading.CancellationToken cancellationToken = default) { }
         public static System.Threading.Tasks.Task<string> ToCurlCommandAsync(this Microsoft.AspNetCore.Http.HttpRequest request) { }
+        public static System.Threading.Tasks.Task<string> ToCurlCommandAsync(this Microsoft.AspNetCore.Http.HttpRequest request, System.Collections.Generic.IReadOnlySet<string>? skipHeaders) { }
     }
     public enum HttpVerb
     {

--- a/Augustus/Augustus/FileManager.cs
+++ b/Augustus/Augustus/FileManager.cs
@@ -168,7 +168,10 @@ public partial class APISimulator
             return await File.ReadAllTextAsync(fullPath).ConfigureAwait(false);
         }
 
-        public async Task CacheResponseAsync(string requestHash, string response, string originalRequest, List<string> instructions)
+        public Task CacheResponseAsync(string requestHash, string response, string originalRequest, List<string> instructions)
+            => CacheResponseAsync(requestHash, response, originalRequest, instructions, normalized: false);
+
+        public async Task CacheResponseAsync(string requestHash, string response, string originalRequest, List<string> instructions, bool normalized)
         {
             ValidateFileName(requestHash);
 
@@ -178,7 +181,8 @@ public partial class APISimulator
                 Response = response,
                 OriginalRequest = SensitiveDataSanitizer.SanitizeSensitiveValues(originalRequest),
                 Instructions = instructions.Select(SensitiveDataSanitizer.SanitizeSensitiveValues).ToList(),
-                Timestamp = DateTime.UtcNow
+                Timestamp = DateTime.UtcNow,
+                Normalized = normalized
             };
 
             var json = JsonSerializer.Serialize(cacheEntry, CacheSerializerOptions);
@@ -187,6 +191,12 @@ public partial class APISimulator
         }
 
         public async Task<string?> ReadCachedResponseAsync(string requestHash)
+        {
+            var entry = await ReadCachedEntryAsync(requestHash).ConfigureAwait(false);
+            return entry?.Response;
+        }
+
+        public async Task<CacheEntry?> ReadCachedEntryAsync(string requestHash)
         {
             ValidateFileName(requestHash);
 
@@ -199,11 +209,10 @@ public partial class APISimulator
                 var cacheEntry = JsonSerializer.Deserialize<CacheEntry>(json);
                 if (cacheEntry?.Response != null)
                     _touchedHashes.TryAdd(requestHash, 0);
-                return cacheEntry?.Response;
+                return cacheEntry;
             }
             catch (JsonException)
             {
-                // Invalid cache file, return null
                 return null;
             }
         }
@@ -313,5 +322,6 @@ public partial class APISimulator
         public string OriginalRequest { get; set; } = string.Empty;
         public List<string> Instructions { get; set; } = new();
         public DateTime Timestamp { get; set; }
+        public bool Normalized { get; set; }
     }
 }

--- a/Augustus/Augustus/HttpRequestExtensions.cs
+++ b/Augustus/Augustus/HttpRequestExtensions.cs
@@ -5,11 +5,14 @@ namespace Augustus;
 
 public static class HttpRequestExtensions
 {
-    internal static readonly HashSet<string> DefaultAISkipHeaders = new(StringComparer.OrdinalIgnoreCase)
+    internal static readonly IReadOnlySet<string> DefaultAISkipHeaders = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
     {
+        // Infrastructure headers — low signal, high token waste
         "Host", "Connection", "Keep-Alive", "Transfer-Encoding",
         "TE", "Trailer", "Upgrade", "Content-Length", "Accept-Encoding",
-        "Proxy-Authorization", "Proxy-Authenticate"
+        "Proxy-Authorization", "Proxy-Authenticate",
+        // Credential-bearing headers — must never be forwarded to the AI model
+        "Authorization", "Cookie", "Set-Cookie", "x-api-key"
     };
 
     public static async Task<byte[]> ReadBodyBytesAsync(this HttpRequest request, CancellationToken cancellationToken = default)

--- a/Augustus/Augustus/HttpRequestExtensions.cs
+++ b/Augustus/Augustus/HttpRequestExtensions.cs
@@ -5,6 +5,13 @@ namespace Augustus;
 
 public static class HttpRequestExtensions
 {
+    internal static readonly HashSet<string> DefaultAISkipHeaders = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "Host", "Connection", "Keep-Alive", "Transfer-Encoding",
+        "TE", "Trailer", "Upgrade", "Content-Length", "Accept-Encoding",
+        "Proxy-Authorization", "Proxy-Authenticate"
+    };
+
     public static async Task<byte[]> ReadBodyBytesAsync(this HttpRequest request, CancellationToken cancellationToken = default)
     {
         request.EnableBuffering();
@@ -14,7 +21,10 @@ public static class HttpRequestExtensions
         return ms.ToArray();
     }
 
-    public static async Task<string> ToCurlCommandAsync(this HttpRequest request)
+    public static Task<string> ToCurlCommandAsync(this HttpRequest request)
+        => ToCurlCommandAsync(request, skipHeaders: null);
+
+    public static async Task<string> ToCurlCommandAsync(this HttpRequest request, IReadOnlySet<string>? skipHeaders)
     {
         StringBuilder curlCommand = new StringBuilder(256); // Pre-allocate with estimated capacity
         curlCommand.Append("curl -X ").Append(request.Method);
@@ -22,6 +32,9 @@ public static class HttpRequestExtensions
         // Append headers (escape double quotes in header values)
         foreach (var header in request.Headers)
         {
+            if (skipHeaders != null && skipHeaders.Contains(header.Key))
+                continue;
+
             var escapedValue = EscapeForDoubleQuotes(header.Value.ToString());
             curlCommand.Append($" -H \"{header.Key}: {escapedValue}\"");
         }


### PR DESCRIPTION
## Summary

- **Lazy curl command generation**: Defers `ToCurlCommandAsync()` until after cache check in both `AIDefaultHandler` and `AIResponseStrategy`, avoiding body re-read, header iteration, and string building on cache hits
- **Skip redundant normalization**: Adds `Normalized` flag to cache entries so already-normalized responses bypass JSON parse/validate/serialize on read (legacy entries still normalized)
- **Filter noisy headers**: Adds `ToCurlCommandAsync(skipHeaders)` overload; AI handlers skip infrastructure headers (Host, Connection, Content-Length, etc.) to reduce OpenAI prompt token waste
- **Deterministic responses**: Sets `Temperature = 0f` in chat completion options, improving cache hit rates for identical prompts
- **Consolidated system instructions**: Joins multiple system messages into one, reducing prompt token overhead from message boundaries

## Test plan
- [x] All 360 tests pass across Augustus.Tests, Augustus.AI.Tests, Augustus.Stripe.Tests, Augustus.GitHub.Tests (net10.0)
- [x] Public API snapshot updated for new `ToCurlCommandAsync` overload
- [ ] Verify with live OpenAI calls that consolidated instructions produce equivalent responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)