### PR TITLE
feat: decouple cache identity from raw-request hash (#106)

### DIFF
--- a/Augustus/Augustus.AI.Tests/CacheOnlyModeTests.cs
+++ b/Augustus/Augustus.AI.Tests/CacheOnlyModeTests.cs
@@ -110,4 +110,43 @@ public class CacheOnlyModeTests : IDisposable
             body.Should().Contain("no cached response found");
         }
     }
+
+    [Fact]
+    public async Task AiCacheMiss_FiresHookAndExtends503_PreservingExistingMessage()
+    {
+        var cacheDir = CreateTempCacheDir();
+        global::Augustus.CacheMissDiagnostic? captured = null;
+        var sim = this.CreateAPISimulator("TestAPI", options =>
+        {
+            options.CacheOnly = true;
+            options.CacheFolderPath = cacheDir;
+            options.Port = 0;
+            options.OnCacheMiss = d => captured = d;
+        });
+        sim.UseAI(new AIOptions());
+        sim.AddInstruction("Return test responses");
+
+        await using (sim)
+        {
+            await sim.StartAsync();
+            using var client = sim.CreateClient();
+
+            var response = await client.GetAsync("/v1/widgets");
+            response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
+            var body = await response.Content.ReadAsStringAsync();
+            using var doc = JsonDocument.Parse(body);
+            var root = doc.RootElement;
+
+            // Existing contract preserved.
+            root.GetProperty("error").GetString().Should().Contain("Cache-only mode");
+            root.GetProperty("status").GetInt32().Should().Be(503);
+            // New diagnostic fields.
+            root.GetProperty("computedKey").GetString().Should().NotBeNullOrEmpty();
+            root.GetProperty("expectedCanonicalRequest").GetProperty("Path").GetString()
+                .Should().Be("/v1/widgets");
+
+            captured.Should().NotBeNull();
+            captured!.ExpectedCanonicalRequest.Method.Should().Be("GET");
+        }
+    }
 }

--- a/Augustus/Augustus.AI.Tests/ProxyCachingTests.cs
+++ b/Augustus/Augustus.AI.Tests/ProxyCachingTests.cs
@@ -202,6 +202,32 @@ public class ProxyCachingTests : IDisposable
     }
 
     [Fact]
+    public async Task EnableCachingFalse_DoesNotFireOnCacheMissHook()
+    {
+        var cacheDir = CreateTempCacheDir();
+        var fired = 0;
+        var sim = this.CreateAPISimulator("TestAPI", options =>
+        {
+            options.EnableCaching = false;       // no cache searched → no miss
+            options.CacheFolderPath = cacheDir;
+            options.Port = 0;
+            options.OnCacheMiss = _ => Interlocked.Increment(ref fired);
+        });
+        sim.UseProxy(new AIOptions(), "https://api.example.com");
+
+        await using (sim)
+        {
+            await sim.StartAsync();
+            using var client = sim.CreateClient();
+            // The proxy without caching will attempt upstream and fail; that's fine — we
+            // only care that OnCacheMiss does not fire when no cache was searched.
+            try { using var _ = await client.GetAsync("/api/whatever"); } catch { }
+        }
+
+        fired.Should().Be(0);
+    }
+
+    [Fact]
     public async Task ProxyCacheOnly_GetRequest_CacheHitServesCorrectResponse()
     {
         var cacheDir = CreateTempCacheDir();

--- a/Augustus/Augustus.AI.Tests/ProxyCachingTests.cs
+++ b/Augustus/Augustus.AI.Tests/ProxyCachingTests.cs
@@ -99,6 +99,109 @@ public class ProxyCachingTests : IDisposable
     }
 
     [Fact]
+    public async Task ProxyCacheOnly_RenamedFixture_IsServedByContentMatch()
+    {
+        var cacheDir = CreateTempCacheDir();
+
+        // A renamed fixture committed before the run (proxy uses no instructions, so the
+        // canonical request is fully deterministic from the request line).
+        var keyResult = global::Augustus.RequestKeyFactory.Create(
+            "GET", "/api/widgets/42", "?expand=true", Array.Empty<byte>(), null, null);
+        var fileManager = new APISimulator.FileManager(cacheDir);
+        await fileManager.CacheResponseAsync(keyResult.Hash, "{\"id\":42,\"name\":\"widget\"}",
+            "PROXY GET /api/widgets/42", new List<string>(), normalized: false, keyResult.Canonical);
+        File.Move(
+            Path.Combine(cacheDir, $"{keyResult.Hash}.json"),
+            Path.Combine(cacheDir, "get-widget-42.json"));
+
+        await using var simulator = CreateCacheOnlyProxySimulator(cacheDir);
+        await simulator.StartAsync();
+        using var client = simulator.CreateClient();
+
+        using var hitResponse = await client.GetAsync("/api/widgets/42?expand=true");
+        hitResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        (await hitResponse.Content.ReadAsStringAsync()).Should().Contain("widget");
+    }
+
+    [Fact]
+    public async Task ProxyCacheOnly_AzureDeploymentRename_StillServedWhenNormalizationEnabled()
+    {
+        var cacheDir = CreateTempCacheDir();
+
+        // Fixture recorded under the original deployment name, NO normalization.
+        var legacy = global::Augustus.RequestKeyFactory.Create(
+            "POST", "/openai/deployments/gpt4-prod/chat/completions", "?api-version=2024-06-01",
+            System.Text.Encoding.UTF8.GetBytes("{\"model\":\"gpt-4\"}"), null, null);
+        var fm = new APISimulator.FileManager(cacheDir);
+        await fm.CacheResponseAsync(legacy.Hash, "{\"id\":\"azure-ok\"}", "PROXY",
+            new List<string>(), normalized: false, legacy.Canonical);
+
+        var sim = this.CreateAPISimulator("TestAPI", options =>
+        {
+            options.CacheOnly = true;
+            options.CacheFolderPath = cacheDir;
+            options.Port = 0;
+            options.NormalizeAzureOpenAIDeployment = true;
+        });
+        sim.UseProxy(new AIOptions(), "https://example.openai.azure.com");
+
+        await using (sim)
+        {
+            await sim.StartAsync();
+            using var client = sim.CreateClient();
+
+            // Upstream deployment was renamed/migrated — different segment, same prompt.
+            using var response = await client.PostAsync(
+                "/openai/deployments/gpt4-prod-eastus2/chat/completions?api-version=2024-06-01",
+                new StringContent("{\"model\":\"gpt-4\"}", System.Text.Encoding.UTF8, "application/json"));
+
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            (await response.Content.ReadAsStringAsync()).Should().Contain("azure-ok");
+        }
+    }
+
+    [Fact]
+    public async Task ProxyCacheOnly_CacheMiss_FiresHookAndExtends503Payload()
+    {
+        var cacheDir = CreateTempCacheDir();
+        global::Augustus.CacheMissDiagnostic? captured = null;
+        var sim = this.CreateAPISimulator("TestAPI", options =>
+        {
+            options.CacheOnly = true;
+            options.CacheFolderPath = cacheDir;
+            options.Port = 0;
+            options.OnCacheMiss = d => captured = d;
+        });
+        sim.UseProxy(new AIOptions(), "https://api.example.com");
+
+        await using (sim)
+        {
+            await sim.StartAsync();
+            using var client = sim.CreateClient();
+
+            using var response = await client.GetAsync("/api/things/7?detail=full");
+            response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
+            var body = await response.Content.ReadAsStringAsync();
+            using var doc = JsonDocument.Parse(body);
+            var root = doc.RootElement;
+
+            // Existing fields preserved.
+            root.GetProperty("status").GetInt32().Should().Be(503);
+            var requestHash = root.GetProperty("requestHash").GetString()!;
+            // New diagnostic field.
+            var canonical = root.GetProperty("expectedCanonicalRequest");
+            canonical.GetProperty("Path").GetString().Should().Be("/api/things/7");
+            canonical.GetProperty("Method").GetString().Should().Be("GET");
+
+            // Hook fired with the same identity.
+            captured.Should().NotBeNull();
+            captured!.ComputedKey.Should().Be(requestHash);
+            captured.ExpectedCanonicalRequest.Path.Should().Be("/api/things/7");
+            captured.CachePath.Should().Be(cacheDir);
+        }
+    }
+
+    [Fact]
     public async Task ProxyCacheOnly_GetRequest_CacheHitServesCorrectResponse()
     {
         var cacheDir = CreateTempCacheDir();

--- a/Augustus/Augustus.AI/AIDefaultHandler.cs
+++ b/Augustus/Augustus.AI/AIDefaultHandler.cs
@@ -71,15 +71,20 @@ internal class AIDefaultHandler : IRequestHandler
 
             if (options.EnableCaching)
             {
-                var cachedEntry = await fileManager
-                    .ResolveEntryAsync(requestHash, c => RequestKeyFactory.ComputeKeyFromCanonical(c, rules))
+                var resolved = await fileManager
+                    .ResolveEntryWithLabelAsync(requestHash, c => RequestKeyFactory.ComputeKeyFromCanonical(c, rules))
                     .ConfigureAwait(false);
-                if (cachedEntry?.Response is { Length: > 0 } cachedResponse)
+                if (resolved is { Entry.Response: { Length: > 0 } cachedResponse } cachedHit)
                 {
-                    if (!cachedEntry.Normalized)
+                    if (!cachedHit.Entry.Normalized)
                     {
                         cachedResponse = ChatCompletionResponseNormalizer.NormalizeIfChatCompletion(
                             cachedResponse, httpContext.Request.Path.Value ?? "/");
+                    }
+                    if (options.BackfillLegacyCanonicalRequest && cachedHit.Entry.CanonicalRequest is null)
+                    {
+                        var label = cachedHit.Label;
+                        _cacheWriter.Enqueue(() => fileManager.BackfillCanonicalAsync(label, canonical));
                     }
                     httpContext.Response.ContentType = "application/json";
                     await httpContext.Response.WriteAsync(cachedResponse, cancellationToken);

--- a/Augustus/Augustus.AI/AIDefaultHandler.cs
+++ b/Augustus/Augustus.AI/AIDefaultHandler.cs
@@ -68,6 +68,10 @@ internal class AIDefaultHandler : IRequestHandler
             var requestHash = keyResult.Hash;
             var materializedBody = keyResult.MaterializedBody;
             var canonical = keyResult.Canonical;
+            // For non-UTF-8 binary bodies the canonical can't be re-hashed losslessly, so
+            // we must persist as legacy (filename-keyed, no canonical) to keep the fixture
+            // resolvable. Same gate applies to the backfill path below.
+            var persistedCanonical = keyResult.CanonicalIsRoundtrippable ? canonical : null;
 
             if (options.EnableCaching)
             {
@@ -81,10 +85,10 @@ internal class AIDefaultHandler : IRequestHandler
                         cachedResponse = ChatCompletionResponseNormalizer.NormalizeIfChatCompletion(
                             cachedResponse, httpContext.Request.Path.Value ?? "/");
                     }
-                    if (options.BackfillLegacyCanonicalRequest && cachedHit.Entry.CanonicalRequest is null)
+                    if (options.BackfillLegacyCanonicalRequest && cachedHit.Entry.CanonicalRequest is null && persistedCanonical is not null)
                     {
                         var label = cachedHit.Label;
-                        _cacheWriter.Enqueue(() => fileManager.BackfillCanonicalAsync(label, canonical));
+                        _cacheWriter.Enqueue(() => fileManager.BackfillCanonicalAsync(label, persistedCanonical));
                     }
                     httpContext.Response.ContentType = "application/json";
                     await httpContext.Response.WriteAsync(cachedResponse, cancellationToken);
@@ -180,7 +184,7 @@ internal class AIDefaultHandler : IRequestHandler
 
             if (options.EnableCaching)
             {
-                _cacheWriter.Enqueue(() => fileManager.CacheResponseAsync(requestHash, responseContent, curlRequest, instructions, normalized: true, canonical));
+                _cacheWriter.Enqueue(() => fileManager.CacheResponseAsync(requestHash, responseContent, curlRequest, instructions, normalized: true, persistedCanonical));
             }
         }
         catch (Exception ex) when (ex is not ArgumentException && ex is not InvalidOperationException)

--- a/Augustus/Augustus.AI/AIDefaultHandler.cs
+++ b/Augustus/Augustus.AI/AIDefaultHandler.cs
@@ -57,18 +57,23 @@ internal class AIDefaultHandler : IRequestHandler
                 httpContext.Request.Path.Value ?? "/",
                 httpContext.Request.Method);
 
-            var requestHash = CacheKeyComputer.ComputeCacheKey(
+            var rules = options.BuildCacheKeyRules();
+            var keyResult = RequestKeyFactory.Create(
                 httpContext.Request.Method,
                 httpContext.Request.Path.Value ?? "/",
                 httpContext.Request.QueryString.Value,
                 bodyBytes,
-                out var materializedBody,
                 instructions,
-                options.DynamicContentFields);
+                rules);
+            var requestHash = keyResult.Hash;
+            var materializedBody = keyResult.MaterializedBody;
+            var canonical = keyResult.Canonical;
 
             if (options.EnableCaching)
             {
-                var cachedEntry = await fileManager.ReadCachedEntryAsync(requestHash).ConfigureAwait(false);
+                var cachedEntry = await fileManager
+                    .ResolveEntryAsync(requestHash, c => RequestKeyFactory.ComputeKeyFromCanonical(c, rules))
+                    .ConfigureAwait(false);
                 if (cachedEntry?.Response is { Length: > 0 } cachedResponse)
                 {
                     if (!cachedEntry.Normalized)
@@ -81,6 +86,9 @@ internal class AIDefaultHandler : IRequestHandler
                     return;
                 }
             }
+
+            options.OnCacheMiss?.Invoke(
+                new CacheMissDiagnostic(canonical, requestHash, fileManager.CurrentCachePath));
 
             if (cacheOnly)
             {
@@ -97,7 +105,8 @@ internal class AIDefaultHandler : IRequestHandler
                     }
                 }
 
-                await WriteErrorResponse(httpContext, message, 503, cancellationToken);
+                await WriteErrorResponse(httpContext, message, 503, cancellationToken,
+                    canonical, requestHash);
                 return;
             }
 
@@ -116,8 +125,16 @@ internal class AIDefaultHandler : IRequestHandler
             // Defer curl command generation until after cache check — avoids re-reading the body stream,
             // iterating headers, and string building on cache hits. Filter noisy headers to reduce
             // OpenAI prompt token usage.
+            IReadOnlySet<string> skipHeaders = HttpRequestExtensions.DefaultAISkipHeaders;
+            if (options.IgnoredHeaders.Count > 0)
+            {
+                var combined = new HashSet<string>(skipHeaders, StringComparer.OrdinalIgnoreCase);
+                foreach (var h in options.IgnoredHeaders)
+                    combined.Add(h);
+                skipHeaders = combined;
+            }
             var curlRequest = await Augustus.HttpRequestExtensions.ToCurlCommandAsync(
-                httpContext.Request, HttpRequestExtensions.DefaultAISkipHeaders).ConfigureAwait(false);
+                httpContext.Request, skipHeaders).ConfigureAwait(false);
             // Sanitize any residual sensitive values (query params, body tokens) before forwarding to OpenAI.
             curlRequest = SensitiveDataSanitizer.SanitizeSensitiveValues(curlRequest);
 
@@ -156,7 +173,7 @@ internal class AIDefaultHandler : IRequestHandler
 
             if (options.EnableCaching)
             {
-                _cacheWriter.Enqueue(() => fileManager.CacheResponseAsync(requestHash, responseContent, curlRequest, instructions, normalized: true));
+                _cacheWriter.Enqueue(() => fileManager.CacheResponseAsync(requestHash, responseContent, curlRequest, instructions, normalized: true, canonical));
             }
         }
         catch (Exception ex) when (ex is not ArgumentException && ex is not InvalidOperationException)
@@ -168,11 +185,22 @@ internal class AIDefaultHandler : IRequestHandler
     public Task DrainPendingCacheWritesAsync(CancellationToken cancellationToken = default)
         => _cacheWriter.DrainAsync(cancellationToken);
 
-    private async Task WriteErrorResponse(HttpContext context, string message, int statusCode, CancellationToken cancellationToken = default)
+    private async Task WriteErrorResponse(HttpContext context, string message, int statusCode, CancellationToken cancellationToken = default, CanonicalRequest? expectedCanonicalRequest = null, string? computedKey = null)
     {
         context.Response.StatusCode = statusCode;
         context.Response.ContentType = "application/json";
-        var errorResponse = JsonSerializer.Serialize(new { error = message, status = statusCode });
+
+        var payload = new Dictionary<string, object?>
+        {
+            ["error"] = message,
+            ["status"] = statusCode,
+        };
+        if (expectedCanonicalRequest is not null)
+            payload["expectedCanonicalRequest"] = expectedCanonicalRequest;
+        if (computedKey is not null)
+            payload["computedKey"] = computedKey;
+
+        var errorResponse = JsonSerializer.Serialize(payload);
         await context.Response.WriteAsync(errorResponse, cancellationToken);
     }
 }

--- a/Augustus/Augustus.AI/AIDefaultHandler.cs
+++ b/Augustus/Augustus.AI/AIDefaultHandler.cs
@@ -90,10 +90,12 @@ internal class AIDefaultHandler : IRequestHandler
                     await httpContext.Response.WriteAsync(cachedResponse, cancellationToken);
                     return;
                 }
-            }
 
-            options.OnCacheMiss?.Invoke(
-                new CacheMissDiagnostic(canonical, requestHash, fileManager.CurrentCachePath));
+                // Only fire after we actually searched the cache and missed — otherwise
+                // consumers with caching disabled would see a misleading miss per request.
+                options.OnCacheMiss?.Invoke(
+                    new CacheMissDiagnostic(canonical, requestHash, fileManager.CurrentCachePath));
+            }
 
             if (cacheOnly)
             {

--- a/Augustus/Augustus.AI/CacheManager.cs
+++ b/Augustus/Augustus.AI/CacheManager.cs
@@ -1,5 +1,6 @@
 namespace Augustus.AI;
 
+using Augustus;
 using System.Text.Json;
 
 /// <summary>
@@ -26,7 +27,7 @@ internal class CacheManager
     public Task CacheResponseAsync(string requestHash, string response, string originalRequest, List<string> instructions)
         => CacheResponseAsync(requestHash, response, originalRequest, instructions, normalized: false);
 
-    public async Task CacheResponseAsync(string requestHash, string response, string originalRequest, List<string> instructions, bool normalized)
+    public async Task CacheResponseAsync(string requestHash, string response, string originalRequest, List<string> instructions, bool normalized, CanonicalRequest? canonical = null)
     {
         var cacheEntry = new CacheEntry
         {
@@ -35,7 +36,8 @@ internal class CacheManager
             OriginalRequest = originalRequest,
             Instructions = instructions,
             Timestamp = DateTime.UtcNow,
-            Normalized = normalized
+            Normalized = normalized,
+            CanonicalRequest = canonical
         };
 
         var json = JsonSerializer.Serialize(cacheEntry, new JsonSerializerOptions { WriteIndented = true });
@@ -110,4 +112,10 @@ internal class CacheEntry
     public List<string> Instructions { get; set; } = new();
     public DateTime Timestamp { get; set; }
     public bool Normalized { get; set; }
+
+    /// <summary>
+    /// The canonical request this fixture matches, written for new entries so the file
+    /// can be renamed or hand-authored. Null for legacy fixtures (matched by filename).
+    /// </summary>
+    public CanonicalRequest? CanonicalRequest { get; set; }
 }

--- a/Augustus/Augustus.AI/CacheManager.cs
+++ b/Augustus/Augustus.AI/CacheManager.cs
@@ -1,6 +1,5 @@
 namespace Augustus.AI;
 
-using Augustus;
 using System.Text.Json;
 
 /// <summary>
@@ -27,7 +26,7 @@ internal class CacheManager
     public Task CacheResponseAsync(string requestHash, string response, string originalRequest, List<string> instructions)
         => CacheResponseAsync(requestHash, response, originalRequest, instructions, normalized: false);
 
-    public async Task CacheResponseAsync(string requestHash, string response, string originalRequest, List<string> instructions, bool normalized, CanonicalRequest? canonical = null)
+    public async Task CacheResponseAsync(string requestHash, string response, string originalRequest, List<string> instructions, bool normalized)
     {
         var cacheEntry = new CacheEntry
         {
@@ -36,8 +35,7 @@ internal class CacheManager
             OriginalRequest = originalRequest,
             Instructions = instructions,
             Timestamp = DateTime.UtcNow,
-            Normalized = normalized,
-            CanonicalRequest = canonical
+            Normalized = normalized
         };
 
         var json = JsonSerializer.Serialize(cacheEntry, new JsonSerializerOptions { WriteIndented = true });
@@ -112,10 +110,4 @@ internal class CacheEntry
     public List<string> Instructions { get; set; } = new();
     public DateTime Timestamp { get; set; }
     public bool Normalized { get; set; }
-
-    /// <summary>
-    /// The canonical request this fixture matches, written for new entries so the file
-    /// can be renamed or hand-authored. Null for legacy fixtures (matched by filename).
-    /// </summary>
-    public CanonicalRequest? CanonicalRequest { get; set; }
 }

--- a/Augustus/Augustus.AI/ProxyDefaultHandler.cs
+++ b/Augustus/Augustus.AI/ProxyDefaultHandler.cs
@@ -65,6 +65,10 @@ internal class ProxyDefaultHandler : IRequestHandler, IDisposable
             var cacheKey = keyResult.Hash;
             var materializedBody = keyResult.MaterializedBody;
             var canonical = keyResult.Canonical;
+            // For non-UTF-8 binary bodies the canonical can't be re-hashed losslessly, so
+            // we must persist as legacy (filename-keyed, no canonical) to keep the fixture
+            // resolvable. Same gate applies to the backfill path below.
+            var persistedCanonical = keyResult.CanonicalIsRoundtrippable ? canonical : null;
 
             if (options.EnableCaching)
             {
@@ -73,10 +77,10 @@ internal class ProxyDefaultHandler : IRequestHandler, IDisposable
                     .ConfigureAwait(false);
                 if (resolved is { Entry.Response: { Length: > 0 } cached })
                 {
-                    if (options.BackfillLegacyCanonicalRequest && resolved.Entry.CanonicalRequest is null)
+                    if (options.BackfillLegacyCanonicalRequest && resolved.Entry.CanonicalRequest is null && persistedCanonical is not null)
                     {
                         var label = resolved.Label;
-                        _cacheWriter.Enqueue(() => fileManager.BackfillCanonicalAsync(label, canonical));
+                        _cacheWriter.Enqueue(() => fileManager.BackfillCanonicalAsync(label, persistedCanonical));
                     }
 
                     context.Response.ContentType = "application/json";
@@ -137,7 +141,7 @@ internal class ProxyDefaultHandler : IRequestHandler, IDisposable
                 _cacheWriter.Enqueue(() =>
                 {
                     var requestInfo = $"PROXY {method} {path}";
-                    return fileManager.CacheResponseAsync(cacheKey, responseBody, requestInfo, new List<string>(), normalized: false, canonical);
+                    return fileManager.CacheResponseAsync(cacheKey, responseBody, requestInfo, new List<string>(), normalized: false, persistedCanonical);
                 });
             }
         }

--- a/Augustus/Augustus.AI/ProxyDefaultHandler.cs
+++ b/Augustus/Augustus.AI/ProxyDefaultHandler.cs
@@ -54,24 +54,33 @@ internal class ProxyDefaultHandler : IRequestHandler, IDisposable
         try
         {
             var bodyBytes = await context.Request.ReadBodyBytesAsync(cancellationToken).ConfigureAwait(false);
-            var cacheKey = CacheKeyComputer.ComputeCacheKey(
+            var rules = options.BuildCacheKeyRules();
+            var keyResult = RequestKeyFactory.Create(
                 context.Request.Method,
                 context.Request.Path.Value ?? "/",
                 context.Request.QueryString.Value,
                 bodyBytes,
-                out var materializedBody,
-                dynamicContentFields: options.DynamicContentFields);
+                null,
+                rules);
+            var cacheKey = keyResult.Hash;
+            var materializedBody = keyResult.MaterializedBody;
+            var canonical = keyResult.Canonical;
 
             if (options.EnableCaching)
             {
-                var cached = await fileManager.ReadCachedResponseAsync(cacheKey).ConfigureAwait(false);
-                if (!string.IsNullOrEmpty(cached))
+                var cachedEntry = await fileManager
+                    .ResolveEntryAsync(cacheKey, c => RequestKeyFactory.ComputeKeyFromCanonical(c, rules))
+                    .ConfigureAwait(false);
+                if (cachedEntry?.Response is { Length: > 0 } cached)
                 {
                     context.Response.ContentType = "application/json";
                     await context.Response.WriteAsync(cached, cancellationToken).ConfigureAwait(false);
                     return;
                 }
             }
+
+            options.OnCacheMiss?.Invoke(
+                new CacheMissDiagnostic(canonical, cacheKey, fileManager.CurrentCachePath));
 
             if (options.CacheOnly)
             {
@@ -81,7 +90,8 @@ internal class ProxyDefaultHandler : IRequestHandler, IDisposable
                 {
                     ["error"] = "Cache miss in CacheOnly mode. No cached response found for this request.",
                     ["status"] = 503,
-                    ["requestHash"] = cacheKey
+                    ["requestHash"] = cacheKey,
+                    ["expectedCanonicalRequest"] = canonical
                 };
                 var digestInputLen = aiOptions.CacheMissMaterializedBodyPrefixSha256ByteCount;
                 if (digestInputLen > 0)
@@ -119,7 +129,7 @@ internal class ProxyDefaultHandler : IRequestHandler, IDisposable
                 _cacheWriter.Enqueue(() =>
                 {
                     var requestInfo = $"PROXY {method} {path}";
-                    return fileManager.CacheResponseAsync(cacheKey, responseBody, requestInfo, new List<string>());
+                    return fileManager.CacheResponseAsync(cacheKey, responseBody, requestInfo, new List<string>(), normalized: false, canonical);
                 });
             }
         }

--- a/Augustus/Augustus.AI/ProxyDefaultHandler.cs
+++ b/Augustus/Augustus.AI/ProxyDefaultHandler.cs
@@ -83,10 +83,12 @@ internal class ProxyDefaultHandler : IRequestHandler, IDisposable
                     await context.Response.WriteAsync(cached, cancellationToken).ConfigureAwait(false);
                     return;
                 }
-            }
 
-            options.OnCacheMiss?.Invoke(
-                new CacheMissDiagnostic(canonical, cacheKey, fileManager.CurrentCachePath));
+                // Only fire after we actually searched the cache and missed — otherwise
+                // consumers with caching disabled would see a misleading miss per request.
+                options.OnCacheMiss?.Invoke(
+                    new CacheMissDiagnostic(canonical, cacheKey, fileManager.CurrentCachePath));
+            }
 
             if (options.CacheOnly)
             {

--- a/Augustus/Augustus.AI/ProxyDefaultHandler.cs
+++ b/Augustus/Augustus.AI/ProxyDefaultHandler.cs
@@ -68,11 +68,17 @@ internal class ProxyDefaultHandler : IRequestHandler, IDisposable
 
             if (options.EnableCaching)
             {
-                var cachedEntry = await fileManager
-                    .ResolveEntryAsync(cacheKey, c => RequestKeyFactory.ComputeKeyFromCanonical(c, rules))
+                var resolved = await fileManager
+                    .ResolveEntryWithLabelAsync(cacheKey, c => RequestKeyFactory.ComputeKeyFromCanonical(c, rules))
                     .ConfigureAwait(false);
-                if (cachedEntry?.Response is { Length: > 0 } cached)
+                if (resolved is { Entry.Response: { Length: > 0 } cached })
                 {
+                    if (options.BackfillLegacyCanonicalRequest && resolved.Entry.CanonicalRequest is null)
+                    {
+                        var label = resolved.Label;
+                        _cacheWriter.Enqueue(() => fileManager.BackfillCanonicalAsync(label, canonical));
+                    }
+
                     context.Response.ContentType = "application/json";
                     await context.Response.WriteAsync(cached, cancellationToken).ConfigureAwait(false);
                     return;

--- a/Augustus/Augustus.Tests/CacheKeyKnobsTests.cs
+++ b/Augustus/Augustus.Tests/CacheKeyKnobsTests.cs
@@ -1,0 +1,99 @@
+using System.Text;
+using Augustus;
+using FluentAssertions;
+
+namespace Augustus.Tests;
+
+public class CacheKeyKnobsTests
+{
+    private static byte[] B(string s) => Encoding.UTF8.GetBytes(s);
+
+    [Fact]
+    public void IgnoredQueryParameters_DoNotChurnKey()
+    {
+        var rules = new CacheKeyRules { IgnoredQueryParameters = new[] { "_t", "nonce" } };
+
+        var a = RequestKeyFactory.Create("GET", "/v1/x", "?id=1&_t=111&nonce=aaa", Array.Empty<byte>(), null, rules);
+        var b = RequestKeyFactory.Create("GET", "/v1/x", "?id=1&_t=999&nonce=zzz", Array.Empty<byte>(), null, rules);
+
+        b.Hash.Should().Be(a.Hash);
+    }
+
+    [Fact]
+    public void IgnoredQueryParameters_RetainedParameterStillMatters()
+    {
+        var rules = new CacheKeyRules { IgnoredQueryParameters = new[] { "_t" } };
+
+        var a = RequestKeyFactory.Create("GET", "/v1/x", "?id=1&_t=1", Array.Empty<byte>(), null, rules);
+        var b = RequestKeyFactory.Create("GET", "/v1/x", "?id=2&_t=1", Array.Empty<byte>(), null, rules);
+
+        a.Hash.Should().NotBe(b.Hash);
+    }
+
+    [Fact]
+    public void StripNullBodyProperties_NullVsOmitted_ProduceSameKey()
+    {
+        var rules = new CacheKeyRules { StripNullBodyProperties = true };
+
+        var withNull = RequestKeyFactory.Create(
+            "POST", "/v1/chat", null, B("{\"model\":\"gpt-4\",\"user\":null}"), null, rules);
+        var omitted = RequestKeyFactory.Create(
+            "POST", "/v1/chat", null, B("{\"model\":\"gpt-4\"}"), null, rules);
+
+        withNull.Hash.Should().Be(omitted.Hash);
+    }
+
+    [Fact]
+    public void StripNullBodyProperties_Disabled_NullVsOmitted_Differ()
+    {
+        var withNull = RequestKeyFactory.Create(
+            "POST", "/v1/chat", null, B("{\"model\":\"gpt-4\",\"user\":null}"), null, null);
+        var omitted = RequestKeyFactory.Create(
+            "POST", "/v1/chat", null, B("{\"model\":\"gpt-4\"}"), null, null);
+
+        withNull.Hash.Should().NotBe(omitted.Hash);
+    }
+
+    [Fact]
+    public void HashMessagesContentOnly_CosmeticNonContentEdits_DoNotChurnKey()
+    {
+        var rules = new CacheKeyRules { HashMessagesContentOnly = true };
+
+        var a = RequestKeyFactory.Create("POST", "/v1/chat", null,
+            B("{\"model\":\"gpt-4\",\"temperature\":0.2,\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}]}"),
+            null, rules);
+        var b = RequestKeyFactory.Create("POST", "/v1/chat", null,
+            B("{\"model\":\"gpt-4-turbo\",\"temperature\":0.9,\"messages\":[{\"role\":\"system\",\"content\":\"hi\"}]}"),
+            null, rules);
+
+        b.Hash.Should().Be(a.Hash);
+    }
+
+    [Fact]
+    public void HashMessagesContentOnly_ContentEditStillChurnsKey()
+    {
+        var rules = new CacheKeyRules { HashMessagesContentOnly = true };
+
+        var a = RequestKeyFactory.Create("POST", "/v1/chat", null,
+            B("{\"messages\":[{\"role\":\"user\",\"content\":\"hello\"}]}"), null, rules);
+        var b = RequestKeyFactory.Create("POST", "/v1/chat", null,
+            B("{\"messages\":[{\"role\":\"user\",\"content\":\"goodbye\"}]}"), null, rules);
+
+        a.Hash.Should().NotBe(b.Hash);
+    }
+
+    [Fact]
+    public void Options_ExposeKnobsAndBuildRules()
+    {
+        var options = new APISimulatorOptions();
+        options.IgnoredHeaders.Add("x-request-id");
+        options.IgnoredQueryParameters.Add("_cb");
+        options.StripNullBodyProperties = true;
+        options.HashMessagesContentOnly = true;
+
+        options.IgnoredHeaders.Should().Contain("x-request-id");
+        options.IgnoredQueryParameters.Should().Contain("_cb");
+        options.StripNullBodyProperties.Should().BeTrue();
+        options.HashMessagesContentOnly.Should().BeTrue();
+    }
+}

--- a/Augustus/Augustus.Tests/CacheKeyKnobsTests.cs
+++ b/Augustus/Augustus.Tests/CacheKeyKnobsTests.cs
@@ -95,6 +95,39 @@ public class CacheKeyKnobsTests
     }
 
     [Fact]
+    public void Create_NonUtf8Body_FlagsCanonicalAsNonRoundtrippable()
+    {
+        // Bytes 0xFF, 0xFE are not valid UTF-8 → GetString produces replacement chars,
+        // GetBytes of that string ≠ original. Persisting CanonicalRequest in that case
+        // would make the fixture unresolvable via both fast-path and content index.
+        var binary = new byte[] { 0xFF, 0xFE, 0x00, 0x01, 0x02 };
+
+        var result = RequestKeyFactory.Create("POST", "/v1/upload", null, binary, null, null);
+
+        result.CanonicalIsRoundtrippable.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Create_Utf8JsonBody_FlagsCanonicalAsRoundtrippable()
+    {
+        var json = Encoding.UTF8.GetBytes("{\"model\":\"gpt-4\",\"x\":\"héllo\"}");
+
+        var result = RequestKeyFactory.Create("POST", "/v1/chat", null, json, null, null);
+
+        result.CanonicalIsRoundtrippable.Should().BeTrue();
+        // And the invariant the renameable feature depends on still holds:
+        RequestKeyFactory.ComputeKeyFromCanonical(result.Canonical, null)
+            .Should().Be(result.Hash);
+    }
+
+    [Fact]
+    public void Create_EmptyBody_FlagsCanonicalAsRoundtrippable()
+    {
+        var result = RequestKeyFactory.Create("GET", "/v1/health", null, Array.Empty<byte>(), null, null);
+        result.CanonicalIsRoundtrippable.Should().BeTrue();
+    }
+
+    [Fact]
     public void Options_ExposeKnobsAndBuildRules()
     {
         var options = new APISimulatorOptions();

--- a/Augustus/Augustus.Tests/CacheKeyKnobsTests.cs
+++ b/Augustus/Augustus.Tests/CacheKeyKnobsTests.cs
@@ -83,6 +83,18 @@ public class CacheKeyKnobsTests
     }
 
     [Fact]
+    public void IgnoredQueryParameters_MalformedPercentEncoding_DoesNotThrow()
+    {
+        // Regression: Uri.UnescapeDataString throws on "?bad=%". The factory must compare
+        // safely so cache-key computation never turns into a 500.
+        var rules = new CacheKeyRules { IgnoredQueryParameters = new[] { "drop" } };
+
+        var act = () => RequestKeyFactory.Create("GET", "/v1/x", "?bad=%&keep=1", Array.Empty<byte>(), null, rules);
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
     public void Options_ExposeKnobsAndBuildRules()
     {
         var options = new APISimulatorOptions();

--- a/Augustus/Augustus.Tests/CacheKeyTests.cs
+++ b/Augustus/Augustus.Tests/CacheKeyTests.cs
@@ -215,4 +215,45 @@ public class CacheKeyTests
 
         hash1.Should().Be(hash2);
     }
+
+    [Fact]
+    public void CacheKeyComputer_NonJsonBody_MatchesHistoricalByteLayout()
+    {
+        // Pins the legacy key layout: UTF8(method) | UTF8(path) | UTF8(query??"") | bodyBytes.
+        // A non-JSON (form) body is passed through unchanged by the normalizer, so the
+        // expected hash can be reconstructed independently of the implementation.
+        const string method = "POST";
+        const string path = "/v1/charges";
+        var bodyBytes = System.Text.Encoding.UTF8.GetBytes("amount=2000&currency=usd&source=tok_visa");
+
+        using var ms = new MemoryStream();
+        void Append(string s) => ms.Write(System.Text.Encoding.UTF8.GetBytes(s));
+        Append(method);
+        Append("|");
+        Append(path);
+        Append("|");
+        Append(string.Empty);
+        Append("|");
+        ms.Write(bodyBytes);
+        var expected = Convert.ToHexString(System.Security.Cryptography.SHA256.HashData(ms.ToArray()));
+
+        var actual = CacheKeyComputer.ComputeCacheKey(method, path, null, bodyBytes);
+
+        actual.Should().Be(expected);
+    }
+
+    [Fact]
+    public void CacheKeyComputer_JsonBody_MatchesPinnedHistoricalHash()
+    {
+        // Pinned value captured from the pre-refactor implementation. Any change here means
+        // every downstream committed fixture would be invalidated — treat a failure as a
+        // signal to add migration/rekey, never as "just update the constant".
+        var body = System.Text.Encoding.UTF8.GetBytes(
+            "{\"model\":\"gpt-4\",\"messages\":[{\"role\":\"user\",\"content\":\"hello\"}]}");
+
+        var hash = CacheKeyComputer.ComputeCacheKey(
+            "POST", "/v1/chat/completions", "?api-version=2024-06-01", body);
+
+        hash.Should().Be("04DADA3079E42C3831F4B0F2B2F419ED8546BE52B43D6DA2374A9605162AD040");
+    }
 }

--- a/Augustus/Augustus.Tests/CacheMaintenanceTests.cs
+++ b/Augustus/Augustus.Tests/CacheMaintenanceTests.cs
@@ -1,0 +1,137 @@
+using System.Text;
+using System.Text.Json;
+using Augustus;
+using FluentAssertions;
+
+namespace Augustus.Tests;
+
+public class CacheMaintenanceTests : IDisposable
+{
+    private readonly List<string> _dirs = new();
+
+    private string NewDir()
+    {
+        var d = Path.Combine(Path.GetTempPath(), $"augustus-rekey-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(d);
+        _dirs.Add(d);
+        return d;
+    }
+
+    public void Dispose()
+    {
+        foreach (var d in _dirs)
+            try { Directory.Delete(d, true); } catch { }
+    }
+
+    private static async Task WriteFixtureAsync(string dir, string fileName, CanonicalRequest canonical, string response)
+    {
+        var json = JsonSerializer.Serialize(new
+        {
+            RequestHash = "irrelevant",
+            Response = response,
+            OriginalRequest = "",
+            Instructions = Array.Empty<string>(),
+            Timestamp = DateTime.UtcNow,
+            Normalized = false,
+            CanonicalRequest = canonical
+        });
+        await File.WriteAllTextAsync(Path.Combine(dir, fileName), json);
+    }
+
+    private static CanonicalRequest CanonicalFor(string method, string path, string? query, string body)
+        => RequestKeyFactory.Create(method, path, query, Encoding.UTF8.GetBytes(body), null, null).Canonical;
+
+    [Fact]
+    public async Task Rekey_RecomputesFilenamesFromCanonicalRequest()
+    {
+        var dir = NewDir();
+        var canonical = CanonicalFor("POST", "/v1/chat", null, "{\"model\":\"gpt-4\"}");
+        await WriteFixtureAsync(dir, "hand-named.json", canonical, "{\"ok\":1}");
+
+        var result = CacheMaintenance.Rekey(dir, new RekeyOptions());
+
+        var expectedKey = RequestKeyFactory.ComputeKeyFromCanonical(canonical, null);
+        result.Scanned.Should().Be(1);
+        result.Renamed.Should().Be(1);
+        File.Exists(Path.Combine(dir, $"{expectedKey}.json")).Should().BeTrue();
+        File.Exists(Path.Combine(dir, "hand-named.json")).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Rekey_AppliesAzureNormalization_RenamesDeploymentAgnostic()
+    {
+        var dir = NewDir();
+        var canonical = CanonicalFor("POST", "/openai/deployments/prod/chat/completions", "?api-version=2024-06-01", "{\"model\":\"gpt-4\"}");
+        await WriteFixtureAsync(dir, "old.json", canonical, "{\"ok\":2}");
+
+        var result = CacheMaintenance.Rekey(dir, new RekeyOptions { NormalizeAzureOpenAIDeployment = true });
+
+        var normRules = new RekeyOptions { NormalizeAzureOpenAIDeployment = true };
+        var expectedKey = RequestKeyFactory.ComputeKeyFromCanonical(canonical, normRules.ToCacheKeyRules());
+        result.Renamed.Should().Be(1);
+        File.Exists(Path.Combine(dir, $"{expectedKey}.json")).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Rekey_DryRun_DoesNotRename()
+    {
+        var dir = NewDir();
+        var canonical = CanonicalFor("GET", "/v1/x", null, "");
+        await WriteFixtureAsync(dir, "keep-me.json", canonical, "{\"ok\":3}");
+
+        var result = CacheMaintenance.Rekey(dir, new RekeyOptions { DryRun = true });
+
+        result.Renamed.Should().Be(1); // would-rename count
+        File.Exists(Path.Combine(dir, "keep-me.json")).Should().BeTrue();
+        Directory.GetFiles(dir, "*.json").Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task Rekey_Conflict_ReportedAndNotOverwritten()
+    {
+        var dir = NewDir();
+        var canonical = CanonicalFor("POST", "/v1/chat", null, "{\"model\":\"gpt-4\"}");
+        await WriteFixtureAsync(dir, "first.json", canonical, "{\"ok\":\"a\"}");
+        await WriteFixtureAsync(dir, "second.json", canonical, "{\"ok\":\"b\"}");
+
+        var result = CacheMaintenance.Rekey(dir, new RekeyOptions());
+
+        result.Conflicts.Should().HaveCount(2);
+        result.Renamed.Should().Be(0);
+        File.Exists(Path.Combine(dir, "first.json")).Should().BeTrue();
+        File.Exists(Path.Combine(dir, "second.json")).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Rekey_LegacyFileWithoutCanonicalRequest_Skipped()
+    {
+        var dir = NewDir();
+        var legacy =
+            "{\"RequestHash\":\"LEGACY\",\"Response\":\"{}\",\"OriginalRequest\":\"\"," +
+            "\"Instructions\":[],\"Timestamp\":\"2024-01-01T00:00:00Z\",\"Normalized\":true}";
+        await File.WriteAllTextAsync(Path.Combine(dir, "LEGACY.json"), legacy);
+
+        var result = CacheMaintenance.Rekey(dir, new RekeyOptions());
+
+        result.Scanned.Should().Be(1);
+        result.Skipped.Should().Be(1);
+        result.Renamed.Should().Be(0);
+        File.Exists(Path.Combine(dir, "LEGACY.json")).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Rekey_Recursive_ProcessesPerContextSubdirectories()
+    {
+        var dir = NewDir();
+        var sub = Path.Combine(dir, "MyScenario");
+        Directory.CreateDirectory(sub);
+        var canonical = CanonicalFor("GET", "/v1/sub", null, "");
+        await WriteFixtureAsync(sub, "renamed-me.json", canonical, "{\"ok\":4}");
+
+        var result = CacheMaintenance.Rekey(dir, new RekeyOptions { Recursive = true });
+
+        var expectedKey = RequestKeyFactory.ComputeKeyFromCanonical(canonical, null);
+        result.Renamed.Should().Be(1);
+        File.Exists(Path.Combine(sub, $"{expectedKey}.json")).Should().BeTrue();
+    }
+}

--- a/Augustus/Augustus.Tests/CacheMaintenanceTests.cs
+++ b/Augustus/Augustus.Tests/CacheMaintenanceTests.cs
@@ -120,6 +120,37 @@ public class CacheMaintenanceTests : IDisposable
     }
 
     [Fact]
+    public async Task Rekey_KeyCycle_ResolvesInOnePassViaTwoPhaseRename()
+    {
+        var dir = NewDir();
+        var canonA = CanonicalFor("POST", "/v1/a", null, "{}");
+        var canonB = CanonicalFor("POST", "/v1/b", null, "{}");
+        var keyA = RequestKeyFactory.ComputeKeyFromCanonical(canonA, null);
+        var keyB = RequestKeyFactory.ComputeKeyFromCanonical(canonB, null);
+        keyA.Should().NotBe(keyB);
+
+        // Cross-keyed: file named {keyB}.json holds canonA, file named {keyA}.json holds canonB.
+        await WriteFixtureAsync(dir, $"{keyB}.json", canonA, "{\"r\":\"a\"}");
+        await WriteFixtureAsync(dir, $"{keyA}.json", canonB, "{\"r\":\"b\"}");
+
+        var result = CacheMaintenance.Rekey(dir, new RekeyOptions());
+
+        result.Renamed.Should().Be(2);
+        result.Conflicts.Should().BeEmpty();
+
+        // Each fixture is now at the file matching its canonical's recomputed key.
+        var atKeyA = JsonSerializer.Deserialize<APISimulator.CacheEntry>(
+            await File.ReadAllTextAsync(Path.Combine(dir, $"{keyA}.json")));
+        var atKeyB = JsonSerializer.Deserialize<APISimulator.CacheEntry>(
+            await File.ReadAllTextAsync(Path.Combine(dir, $"{keyB}.json")));
+        atKeyA!.Response.Should().Be("{\"r\":\"a\"}");
+        atKeyB!.Response.Should().Be("{\"r\":\"b\"}");
+
+        // No temp files left behind.
+        Directory.GetFiles(dir, "*.rekey.tmp").Should().BeEmpty();
+    }
+
+    [Fact]
     public async Task Rekey_Recursive_ProcessesPerContextSubdirectories()
     {
         var dir = NewDir();

--- a/Augustus/Augustus.Tests/CanonicalBackfillTests.cs
+++ b/Augustus/Augustus.Tests/CanonicalBackfillTests.cs
@@ -1,0 +1,148 @@
+using FluentAssertions;
+using System.Text;
+using System.Text.Json;
+
+namespace Augustus.Tests;
+
+/// <summary>
+/// Validates the legacy-fixture backfill path added on top of PR #106 so a pre-canonical
+/// fixture (Augustus 0.8.0 and earlier) can gain a <c>CanonicalRequest</c> without any
+/// upstream API call — making it eligible for <see cref="CacheMaintenance.Rekey"/>.
+/// </summary>
+public class CanonicalBackfillTests
+{
+    private static readonly Func<CanonicalRequest, string> Recompute =
+        c => RequestKeyFactory.ComputeKeyFromCanonical(c, null);
+
+    private static (string key, CanonicalRequest canonical) BuildKey(
+        string method, string path, string? query, byte[] body)
+    {
+        var result = RequestKeyFactory.Create(method, path, query, body, null, null);
+        return (result.Hash, result.Canonical);
+    }
+
+    private static async Task WriteLegacyFixtureAsync(string cachePath, string label, string response)
+    {
+        var legacyJson =
+            "{\"RequestHash\":\"" + label + "\"," +
+            "\"Response\":" + JsonSerializer.Serialize(response) + "," +
+            "\"OriginalRequest\":\"\",\"Instructions\":[]," +
+            "\"Timestamp\":\"2024-01-01T00:00:00Z\",\"Normalized\":true}";
+        await File.WriteAllTextAsync(Path.Combine(cachePath, $"{label}.json"), legacyJson);
+    }
+
+    [Fact]
+    public async Task BackfillCanonicalAsync_OnLegacyFile_WritesCanonicalAndEnablesRekey()
+    {
+        var cachePath = Path.Combine(Path.GetTempPath(), $"augustus-backfill-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(cachePath);
+        try
+        {
+            var body = Encoding.UTF8.GetBytes("{\"model\":\"gpt-4\"}");
+            var (legacyKey, canonical) = BuildKey("POST", "/openai/deployments/old-dev/chat/completions", null, body);
+
+            // Seed a legacy fixture under the legacy hash filename, with NO CanonicalRequest.
+            await WriteLegacyFixtureAsync(cachePath, legacyKey, "{\"ok\":\"legacy\"}");
+
+            // Sanity: legacy file deserializes but has no CanonicalRequest.
+            var fmCheck = new APISimulator.FileManager(cachePath);
+            var pre = await fmCheck.ReadCachedEntryAsync(legacyKey);
+            pre.Should().NotBeNull();
+            pre!.CanonicalRequest.Should().BeNull();
+
+            // Act: backfill in place.
+            var fm = new APISimulator.FileManager(cachePath);
+            var wrote = await fm.BackfillCanonicalAsync(legacyKey, canonical);
+
+            // Assert: file gained a CanonicalRequest, response untouched.
+            wrote.Should().BeTrue();
+            var post = await fm.ReadCachedEntryAsync(legacyKey);
+            post.Should().NotBeNull();
+            post!.CanonicalRequest.Should().NotBeNull();
+            post.Response.Should().Be("{\"ok\":\"legacy\"}");
+
+            // And: CacheMaintenance.Rekey now treats it as a first-class fixture (no longer skipped).
+            // Rekeying with the same rules used to build the key is a no-op rename (same filename),
+            // so we use a normalization knob to force a rename and prove Rekey processed the file.
+            var rekeyResult = CacheMaintenance.Rekey(cachePath, new RekeyOptions
+            {
+                NormalizeAzureOpenAIDeployment = true,
+                Recursive = false,
+                DryRun = false,
+            });
+
+            rekeyResult.Skipped.Should().Be(0, "the backfilled CanonicalRequest makes Rekey able to process the file");
+            rekeyResult.Conflicts.Should().BeEmpty();
+            rekeyResult.Renamed.Should().Be(1, "normalization changed the key, so the file should be renamed");
+            File.Exists(Path.Combine(cachePath, $"{legacyKey}.json")).Should().BeFalse("file was renamed under the new key");
+        }
+        finally { Directory.Delete(cachePath, true); }
+    }
+
+    [Fact]
+    public async Task BackfillCanonicalAsync_AlreadyHasCanonical_IsIdempotentNoOp()
+    {
+        var cachePath = Path.Combine(Path.GetTempPath(), $"augustus-backfill-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(cachePath);
+        try
+        {
+            var body = Encoding.UTF8.GetBytes("{\"model\":\"gpt-4\"}");
+            var (key, canonical) = BuildKey("POST", "/v1/chat/completions", null, body);
+
+            // Seed a *new-format* fixture (already has CanonicalRequest).
+            var fm = new APISimulator.FileManager(cachePath);
+            await fm.CacheResponseAsync(key, "{\"ok\":1}", "curl", new List<string>(), true, canonical);
+
+            var fullPath = Path.Combine(cachePath, $"{key}.json");
+            var beforeMtime = File.GetLastWriteTimeUtc(fullPath);
+
+            // Force a perceptible mtime gap on filesystems with second-level granularity.
+            await Task.Delay(1100);
+
+            // Act: backfill with the same canonical it already has.
+            var wrote = await fm.BackfillCanonicalAsync(key, canonical);
+
+            // Assert: no write happened.
+            wrote.Should().BeFalse("BackfillCanonicalAsync is idempotent when CanonicalRequest is already present");
+            File.GetLastWriteTimeUtc(fullPath).Should().Be(beforeMtime, "file should not have been rewritten");
+        }
+        finally { Directory.Delete(cachePath, true); }
+    }
+
+    [Fact]
+    public async Task BackfillLegacyCanonicalRequest_DefaultOff_LegacyFilePreservedByteIdentical()
+    {
+        // This guards the "default behavior is byte-identical to before" promise of PR #106
+        // even with the new backfill feature in the codebase: an APISimulatorOptions with
+        // the default value (false) for BackfillLegacyCanonicalRequest must not trigger any
+        // mutation of legacy fixtures during normal lookups. We assert at the option-default
+        // level here; integration coverage that exercises the handler path lives in
+        // RefineAI's Server.Specs (Phase 3 of the migration plan).
+        var options = new APISimulatorOptions();
+        options.BackfillLegacyCanonicalRequest.Should().BeFalse(
+            "default must remain off so existing fixtures are byte-identical without opt-in");
+
+        // And: invoking BackfillCanonicalAsync directly is still a controlled op — when the
+        // file already lacks a CanonicalRequest and the option is OFF, the handler simply
+        // would not call BackfillCanonicalAsync at all (verified by the option guard in
+        // ProxyDefaultHandler/AIDefaultHandler). Here we just round-trip read a legacy file
+        // through ReadCachedEntryAsync to confirm no in-place migration happens on read.
+        var cachePath = Path.Combine(Path.GetTempPath(), $"augustus-backfill-default-off-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(cachePath);
+        try
+        {
+            await WriteLegacyFixtureAsync(cachePath, "LEGACYKEY", "{\"ok\":\"legacy\"}");
+            var fullPath = Path.Combine(cachePath, "LEGACYKEY.json");
+            var beforeBytes = await File.ReadAllBytesAsync(fullPath);
+
+            var fm = new APISimulator.FileManager(cachePath);
+            var hit = await fm.ResolveEntryAsync("LEGACYKEY", Recompute);
+            hit.Should().NotBeNull();
+            hit!.CanonicalRequest.Should().BeNull();
+
+            var afterBytes = await File.ReadAllBytesAsync(fullPath);
+            afterBytes.Should().Equal(beforeBytes, "a read with default options must not mutate a legacy fixture on disk");
+        }
+        finally { Directory.Delete(cachePath, true); }
+    }
+}

--- a/Augustus/Augustus.Tests/FileManagerTests.cs
+++ b/Augustus/Augustus.Tests/FileManagerTests.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using System.Text;
 using System.Text.Json;
 
 namespace Augustus.Tests;
@@ -251,5 +252,199 @@ public class FileManagerTests
 
         var act = () => fileManager.RemoveStaleEntries();
         act.Should().NotThrow();
+    }
+
+    [Fact]
+    public async Task CacheResponseAsync_PersistsCanonicalRequest()
+    {
+        var cachePath = Path.Combine(Path.GetTempPath(), $"augustus-cache-tests-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(cachePath);
+        try
+        {
+            var fileManager = new APISimulator.FileManager(cachePath);
+            var canonical = new CanonicalRequest(
+                "POST", "/v1/chat/completions", "?api-version=2024-06-01",
+                new[] { "be terse" }, "{\"model\":\"gpt-4\"}");
+
+            await fileManager.CacheResponseAsync("ABCDEF", "{\"ok\":true}", "curl ...",
+                new List<string> { "be terse" }, normalized: true, canonical: canonical);
+
+            var entry = await fileManager.ReadCachedEntryAsync("ABCDEF");
+            entry.Should().NotBeNull();
+            entry!.CanonicalRequest.Should().NotBeNull();
+            entry.CanonicalRequest!.Method.Should().Be("POST");
+            entry.CanonicalRequest.Path.Should().Be("/v1/chat/completions");
+            entry.CanonicalRequest.NormalizedBody.Should().Be("{\"model\":\"gpt-4\"}");
+        }
+        finally
+        {
+            if (Directory.Exists(cachePath))
+                Directory.Delete(cachePath, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task ReadCachedEntryAsync_LegacyFileWithoutCanonicalRequest_StillDeserializes()
+    {
+        var cachePath = Path.Combine(Path.GetTempPath(), $"augustus-cache-tests-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(cachePath);
+        try
+        {
+            // Pre-#106 on-disk shape: no CanonicalRequest field.
+            var legacyJson =
+                "{\"RequestHash\":\"DEADBEEF\",\"Response\":\"{\\\"ok\\\":true}\"," +
+                "\"OriginalRequest\":\"curl ...\",\"Instructions\":[],\"Timestamp\":\"2024-01-01T00:00:00Z\"," +
+                "\"Normalized\":true}";
+            await File.WriteAllTextAsync(Path.Combine(cachePath, "DEADBEEF.json"), legacyJson);
+
+            var fileManager = new APISimulator.FileManager(cachePath);
+            var entry = await fileManager.ReadCachedEntryAsync("DEADBEEF");
+
+            entry.Should().NotBeNull();
+            entry!.Response.Should().Be("{\"ok\":true}");
+            entry.CanonicalRequest.Should().BeNull();
+        }
+        finally
+        {
+            if (Directory.Exists(cachePath))
+                Directory.Delete(cachePath, recursive: true);
+        }
+    }
+
+    private static readonly Func<CanonicalRequest, string> Recompute =
+        c => RequestKeyFactory.ComputeKeyFromCanonical(c, null);
+
+    private static (string key, CanonicalRequest canonical) BuildKey(
+        string method, string path, string? query, byte[] body)
+    {
+        var result = RequestKeyFactory.Create(method, path, query, body, null, null);
+        return (result.Hash, result.Canonical);
+    }
+
+    [Fact]
+    public async Task ResolveEntryAsync_FilenameEqualsHash_ResolvesViaFastPath()
+    {
+        var cachePath = Path.Combine(Path.GetTempPath(), $"augustus-cache-tests-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(cachePath);
+        try
+        {
+            var body = Encoding.UTF8.GetBytes("{\"model\":\"gpt-4\"}");
+            var (key, canonical) = BuildKey("POST", "/v1/chat/completions", null, body);
+            var fm = new APISimulator.FileManager(cachePath);
+            await fm.CacheResponseAsync(key, "{\"ok\":1}", "curl", new List<string>(), true, canonical);
+
+            var entry = await fm.ResolveEntryAsync(key, Recompute);
+
+            entry.Should().NotBeNull();
+            entry!.Response.Should().Be("{\"ok\":1}");
+        }
+        finally { Directory.Delete(cachePath, true); }
+    }
+
+    [Fact]
+    public async Task ResolveEntryAsync_RenamedFile_ResolvesByCanonicalRequest()
+    {
+        var cachePath = Path.Combine(Path.GetTempPath(), $"augustus-cache-tests-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(cachePath);
+        try
+        {
+            var body = Encoding.UTF8.GetBytes("{\"model\":\"gpt-4\"}");
+            var (key, canonical) = BuildKey("POST", "/v1/chat/completions", null, body);
+            var fm = new APISimulator.FileManager(cachePath);
+            await fm.CacheResponseAsync(key, "{\"ok\":2}", "curl", new List<string>(), true, canonical);
+
+            // Rename the fixture to a human-friendly label.
+            File.Move(
+                Path.Combine(cachePath, $"{key}.json"),
+                Path.Combine(cachePath, "happy-path-chat.json"));
+
+            // Fresh manager so no in-memory state remembers the original name.
+            var fm2 = new APISimulator.FileManager(cachePath);
+            var entry = await fm2.ResolveEntryAsync(key, Recompute);
+
+            entry.Should().NotBeNull();
+            entry!.Response.Should().Be("{\"ok\":2}");
+        }
+        finally { Directory.Delete(cachePath, true); }
+    }
+
+    [Fact]
+    public async Task ResolveEntryAsync_HandAuthoredFile_ResolvesByCanonicalRequest()
+    {
+        var cachePath = Path.Combine(Path.GetTempPath(), $"augustus-cache-tests-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(cachePath);
+        try
+        {
+            var body = Encoding.UTF8.GetBytes("{\"model\":\"gpt-4\"}");
+            var (key, canonical) = BuildKey("POST", "/v1/chat/completions", null, body);
+
+            // Author a fixture entirely by hand under an arbitrary name.
+            var handAuthored = new
+            {
+                RequestHash = "ignored",
+                Response = "{\"ok\":\"hand\"}",
+                OriginalRequest = "",
+                Instructions = Array.Empty<string>(),
+                Timestamp = DateTime.UtcNow,
+                Normalized = true,
+                CanonicalRequest = canonical
+            };
+            await File.WriteAllTextAsync(
+                Path.Combine(cachePath, "authored-by-a-human.json"),
+                JsonSerializer.Serialize(handAuthored));
+
+            var fm = new APISimulator.FileManager(cachePath);
+            var entry = await fm.ResolveEntryAsync(key, Recompute);
+
+            entry.Should().NotBeNull();
+            entry!.Response.Should().Be("{\"ok\":\"hand\"}");
+        }
+        finally { Directory.Delete(cachePath, true); }
+    }
+
+    [Fact]
+    public async Task RemoveStaleEntries_KeepsContentMatchedRenamedFile()
+    {
+        var cachePath = Path.Combine(Path.GetTempPath(), $"augustus-cache-tests-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(cachePath);
+        try
+        {
+            var body = Encoding.UTF8.GetBytes("{\"model\":\"gpt-4\"}");
+            var (key, canonical) = BuildKey("POST", "/v1/chat/completions", null, body);
+            var fm = new APISimulator.FileManager(cachePath);
+            await fm.CacheResponseAsync(key, "{\"ok\":3}", "curl", new List<string>(), true, canonical);
+            File.Move(
+                Path.Combine(cachePath, $"{key}.json"),
+                Path.Combine(cachePath, "renamed.json"));
+
+            var fm2 = new APISimulator.FileManager(cachePath);
+            (await fm2.ResolveEntryAsync(key, Recompute)).Should().NotBeNull();
+            fm2.RemoveStaleEntries();
+
+            File.Exists(Path.Combine(cachePath, "renamed.json")).Should().BeTrue();
+        }
+        finally { Directory.Delete(cachePath, true); }
+    }
+
+    [Fact]
+    public async Task ResolveEntryAsync_LegacyFileNoCanonicalRequest_ResolvesByFilename()
+    {
+        var cachePath = Path.Combine(Path.GetTempPath(), $"augustus-cache-tests-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(cachePath);
+        try
+        {
+            var legacyJson =
+                "{\"RequestHash\":\"LEGACYKEY\",\"Response\":\"{\\\"ok\\\":\\\"legacy\\\"}\"," +
+                "\"OriginalRequest\":\"\",\"Instructions\":[],\"Timestamp\":\"2024-01-01T00:00:00Z\"," +
+                "\"Normalized\":true}";
+            await File.WriteAllTextAsync(Path.Combine(cachePath, "LEGACYKEY.json"), legacyJson);
+
+            var fm = new APISimulator.FileManager(cachePath);
+            var entry = await fm.ResolveEntryAsync("LEGACYKEY", Recompute);
+
+            entry.Should().NotBeNull();
+            entry!.Response.Should().Be("{\"ok\":\"legacy\"}");
+        }
+        finally { Directory.Delete(cachePath, true); }
     }
 }

--- a/Augustus/Augustus.Tests/FileManagerTests.cs
+++ b/Augustus/Augustus.Tests/FileManagerTests.cs
@@ -427,6 +427,93 @@ public class FileManagerTests
     }
 
     [Fact]
+    public async Task ResolveEntryAsync_FastPath_RejectsLabelMismatch_FallsThroughToContent()
+    {
+        var cachePath = Path.Combine(Path.GetTempPath(), $"augustus-cache-tests-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(cachePath);
+        try
+        {
+            // Fixture A's canonical, but parked at filename = fixture B's hash on disk.
+            var bodyA = Encoding.UTF8.GetBytes("{\"model\":\"A\"}");
+            var bodyB = Encoding.UTF8.GetBytes("{\"model\":\"B\"}");
+            var (keyA, canonicalA) = BuildKey("POST", "/v1/x", null, bodyA);
+            var (keyB, _) = BuildKey("POST", "/v1/x", null, bodyB);
+            keyA.Should().NotBe(keyB);
+
+            // Author A's canonical under B's hash name — a stale/misplaced file.
+            var bogus = new
+            {
+                RequestHash = "ignored",
+                Response = "{\"served\":\"wrong\"}",
+                OriginalRequest = "",
+                Instructions = Array.Empty<string>(),
+                Timestamp = DateTime.UtcNow,
+                Normalized = true,
+                CanonicalRequest = canonicalA
+            };
+            await File.WriteAllTextAsync(
+                Path.Combine(cachePath, $"{keyB}.json"),
+                JsonSerializer.Serialize(bogus));
+
+            // Asking for keyB: fast path finds {keyB}.json, but its CanonicalRequest
+            // recomputes to keyA — must reject, not return the wrong response.
+            var fm = new APISimulator.FileManager(cachePath);
+            var entry = await fm.ResolveEntryAsync(keyB, Recompute);
+            entry.Should().BeNull();
+
+            // Asking for keyA: fast path misses, content lookup finds it under keyB.json.
+            var fm2 = new APISimulator.FileManager(cachePath);
+            var match = await fm2.ResolveEntryAsync(keyA, Recompute);
+            match.Should().NotBeNull();
+            match!.Response.Should().Contain("wrong"); // body content, matched correctly
+        }
+        finally { Directory.Delete(cachePath, true); }
+    }
+
+    [Fact]
+    public async Task GetOrBuildIndex_KeyCollision_FirstWins_NoSilentOverwrite()
+    {
+        var cachePath = Path.Combine(Path.GetTempPath(), $"augustus-cache-tests-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(cachePath);
+        try
+        {
+            // Two fixtures with the SAME canonical (so they recompute to the same key)
+            // but different file names and different responses.
+            var body = Encoding.UTF8.GetBytes("{\"model\":\"gpt-4\"}");
+            var (_, canonical) = BuildKey("POST", "/v1/x", null, body);
+
+            async Task Write(string name, string response)
+            {
+                var fixture = new
+                {
+                    RequestHash = "ignored",
+                    Response = response,
+                    OriginalRequest = "",
+                    Instructions = Array.Empty<string>(),
+                    Timestamp = DateTime.UtcNow,
+                    Normalized = true,
+                    CanonicalRequest = canonical
+                };
+                await File.WriteAllTextAsync(
+                    Path.Combine(cachePath, name),
+                    JsonSerializer.Serialize(fixture));
+            }
+            await Write("aaa.json", "{\"served\":\"first\"}");
+            await Write("zzz.json", "{\"served\":\"second\"}");
+
+            var key = RequestKeyFactory.ComputeKeyFromCanonical(canonical, null);
+            var fm = new APISimulator.FileManager(cachePath);
+            var entry = await fm.ResolveEntryAsync(key, Recompute);
+
+            // First-wins behavior is deterministic; the other file is not silently served.
+            entry.Should().NotBeNull();
+            (entry!.Response == "{\"served\":\"first\"}" || entry.Response == "{\"served\":\"second\"}")
+                .Should().BeTrue();
+        }
+        finally { Directory.Delete(cachePath, true); }
+    }
+
+    [Fact]
     public async Task ResolveEntryAsync_LegacyFileNoCanonicalRequest_ResolvesByFilename()
     {
         var cachePath = Path.Combine(Path.GetTempPath(), $"augustus-cache-tests-{Guid.NewGuid():N}");

--- a/Augustus/Augustus.Tests/FileManagerTests.cs
+++ b/Augustus/Augustus.Tests/FileManagerTests.cs
@@ -471,14 +471,15 @@ public class FileManagerTests
     }
 
     [Fact]
-    public async Task GetOrBuildIndex_KeyCollision_FirstWins_NoSilentOverwrite()
+    public async Task GetOrBuildIndex_KeyCollision_FirstWinsByOrdinalSort_Deterministic()
     {
         var cachePath = Path.Combine(Path.GetTempPath(), $"augustus-cache-tests-{Guid.NewGuid():N}");
         Directory.CreateDirectory(cachePath);
         try
         {
-            // Two fixtures with the SAME canonical (so they recompute to the same key)
-            // but different file names and different responses.
+            // Three fixtures with the SAME canonical (so they recompute to the same key)
+            // but file names that DO NOT match filesystem-enumeration order — the index
+            // build must sort to make first-wins reproducible across machines.
             var body = Encoding.UTF8.GetBytes("{\"model\":\"gpt-4\"}");
             var (_, canonical) = BuildKey("POST", "/v1/x", null, body);
 
@@ -498,17 +499,18 @@ public class FileManagerTests
                     Path.Combine(cachePath, name),
                     JsonSerializer.Serialize(fixture));
             }
-            await Write("aaa.json", "{\"served\":\"first\"}");
-            await Write("zzz.json", "{\"served\":\"second\"}");
+            // Write order != ordinal order so we can't accidentally pass via fs ordering.
+            await Write("mmm.json", "{\"served\":\"middle\"}");
+            await Write("aaa.json", "{\"served\":\"alpha\"}");
+            await Write("zzz.json", "{\"served\":\"omega\"}");
 
             var key = RequestKeyFactory.ComputeKeyFromCanonical(canonical, null);
             var fm = new APISimulator.FileManager(cachePath);
             var entry = await fm.ResolveEntryAsync(key, Recompute);
 
-            // First-wins behavior is deterministic; the other file is not silently served.
+            // Deterministic: first by ordinal-sorted filename wins.
             entry.Should().NotBeNull();
-            (entry!.Response == "{\"served\":\"first\"}" || entry.Response == "{\"served\":\"second\"}")
-                .Should().BeTrue();
+            entry!.Response.Should().Be("{\"served\":\"alpha\"}");
         }
         finally { Directory.Delete(cachePath, true); }
     }

--- a/Augustus/Augustus.Tests/PublicApiTests.ApprovePublicApi.verified.txt
+++ b/Augustus/Augustus.Tests/PublicApiTests.ApprovePublicApi.verified.txt
@@ -80,6 +80,8 @@ namespace Augustus
         public string NormalizedBody { get; init; }
         public string Path { get; init; }
         public string? QueryString { get; init; }
+        public bool Equals(Augustus.CanonicalRequest? other) { }
+        public override int GetHashCode() { }
     }
     public sealed class DeliveredWebhook : System.IEquatable<Augustus.DeliveredWebhook>
     {
@@ -169,6 +171,8 @@ namespace Augustus
         public string NormalizedBody { get; init; }
         public string Path { get; init; }
         public string? QueryString { get; init; }
+        public bool Equals(Augustus.RequestKey? other) { }
+        public override int GetHashCode() { }
     }
     public sealed class RouteBuilder
     {

--- a/Augustus/Augustus.Tests/PublicApiTests.ApprovePublicApi.verified.txt
+++ b/Augustus/Augustus.Tests/PublicApiTests.ApprovePublicApi.verified.txt
@@ -50,8 +50,35 @@ namespace Augustus
         public bool CacheOnly { get; set; }
         public System.Collections.Generic.IList<string> DynamicContentFields { get; }
         public bool EnableCaching { get; set; }
+        public bool HashMessagesContentOnly { get; set; }
+        public System.Collections.Generic.IList<string> IgnoredHeaders { get; }
+        public System.Collections.Generic.IList<string> IgnoredQueryParameters { get; }
+        public bool NormalizeAzureOpenAIDeployment { get; set; }
+        public System.Action<Augustus.CacheMissDiagnostic>? OnCacheMiss { get; set; }
         public int Port { get; set; }
+        public System.Func<Augustus.RequestKey, Augustus.RequestKey>? RequestKeyTransform { get; set; }
+        public bool StripNullBodyProperties { get; set; }
         public void Validate() { }
+    }
+    public static class CacheMaintenance
+    {
+        public static Augustus.RekeyResult Rekey(string cachePath, Augustus.RekeyOptions options) { }
+    }
+    public sealed class CacheMissDiagnostic : System.IEquatable<Augustus.CacheMissDiagnostic>
+    {
+        public CacheMissDiagnostic(Augustus.CanonicalRequest ExpectedCanonicalRequest, string ComputedKey, string CachePath) { }
+        public string CachePath { get; init; }
+        public string ComputedKey { get; init; }
+        public Augustus.CanonicalRequest ExpectedCanonicalRequest { get; init; }
+    }
+    public sealed class CanonicalRequest : System.IEquatable<Augustus.CanonicalRequest>
+    {
+        public CanonicalRequest(string Method, string Path, string? QueryString, System.Collections.Generic.IReadOnlyList<string> Instructions, string NormalizedBody) { }
+        public System.Collections.Generic.IReadOnlyList<string> Instructions { get; init; }
+        public string Method { get; init; }
+        public string NormalizedBody { get; init; }
+        public string Path { get; init; }
+        public string? QueryString { get; init; }
     }
     public sealed class DeliveredWebhook : System.IEquatable<Augustus.DeliveredWebhook>
     {
@@ -112,6 +139,35 @@ namespace Augustus
         public System.Net.Http.HttpMethod Method { get; init; }
         public string Path { get; init; }
         public System.DateTimeOffset Timestamp { get; init; }
+    }
+    public sealed class RekeyOptions
+    {
+        public RekeyOptions() { }
+        public bool DryRun { get; set; }
+        public System.Collections.Generic.IList<string> DynamicContentFields { get; }
+        public bool HashMessagesContentOnly { get; set; }
+        public System.Collections.Generic.IList<string> IgnoredQueryParameters { get; }
+        public bool NormalizeAzureOpenAIDeployment { get; set; }
+        public bool Recursive { get; set; }
+        public System.Func<Augustus.RequestKey, Augustus.RequestKey>? RequestKeyTransform { get; set; }
+        public bool StripNullBodyProperties { get; set; }
+    }
+    public sealed class RekeyResult : System.IEquatable<Augustus.RekeyResult>
+    {
+        public RekeyResult(int Scanned, int Renamed, int Skipped, System.Collections.Generic.IReadOnlyList<string> Conflicts) { }
+        public System.Collections.Generic.IReadOnlyList<string> Conflicts { get; init; }
+        public int Renamed { get; init; }
+        public int Scanned { get; init; }
+        public int Skipped { get; init; }
+    }
+    public sealed class RequestKey : System.IEquatable<Augustus.RequestKey>
+    {
+        public RequestKey(string Method, string Path, string? QueryString, System.Collections.Generic.IReadOnlyList<string> Instructions, string NormalizedBody) { }
+        public System.Collections.Generic.IReadOnlyList<string> Instructions { get; init; }
+        public string Method { get; init; }
+        public string NormalizedBody { get; init; }
+        public string Path { get; init; }
+        public string? QueryString { get; init; }
     }
     public sealed class RouteBuilder
     {

--- a/Augustus/Augustus.Tests/PublicApiTests.ApprovePublicApi.verified.txt
+++ b/Augustus/Augustus.Tests/PublicApiTests.ApprovePublicApi.verified.txt
@@ -46,6 +46,7 @@ namespace Augustus
     {
         public APISimulatorOptions() { }
         public bool AutoRemoveStaleCache { get; set; }
+        public bool BackfillLegacyCanonicalRequest { get; set; }
         public string CacheFolderPath { get; set; }
         public bool CacheOnly { get; set; }
         public System.Collections.Generic.IList<string> DynamicContentFields { get; }

--- a/Augustus/Augustus.Tests/RequestKeyTests.cs
+++ b/Augustus/Augustus.Tests/RequestKeyTests.cs
@@ -1,0 +1,61 @@
+using Augustus;
+using FluentAssertions;
+
+namespace Augustus.Tests;
+
+public class RequestKeyTests
+{
+    [Fact]
+    public void RequestKey_SameScalarFields_AreEqual()
+    {
+        var instructions = new List<string> { "a", "b" };
+        var k1 = new RequestKey("POST", "/v1/chat/completions", "?x=1", instructions, "{\"m\":1}");
+        var k2 = new RequestKey("POST", "/v1/chat/completions", "?x=1", instructions, "{\"m\":1}");
+
+        k2.Should().Be(k1);
+        k2.GetHashCode().Should().Be(k1.GetHashCode());
+    }
+
+    [Fact]
+    public void RequestKey_WithCopy_RewritesPathOnly()
+    {
+        var original = new RequestKey(
+            "POST",
+            "/openai/deployments/gpt-4-prod/chat/completions",
+            null,
+            Array.Empty<string>(),
+            "{}");
+
+        var rewritten = original with
+        {
+            Path = "/openai/deployments/__DEPLOYMENT__/chat/completions"
+        };
+
+        rewritten.Path.Should().Be("/openai/deployments/__DEPLOYMENT__/chat/completions");
+        rewritten.Method.Should().Be(original.Method);
+        rewritten.NormalizedBody.Should().Be(original.NormalizedBody);
+        rewritten.Should().NotBe(original);
+    }
+
+    [Fact]
+    public void CanonicalRequest_RoundTripsScalarFields()
+    {
+        var canonical = new CanonicalRequest("GET", "/health", "?probe=1", Array.Empty<string>(), "");
+
+        canonical.Method.Should().Be("GET");
+        canonical.Path.Should().Be("/health");
+        canonical.QueryString.Should().Be("?probe=1");
+        canonical.NormalizedBody.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void CacheMissDiagnostic_ExposesExpectedIdentity()
+    {
+        var canonical = new CanonicalRequest("POST", "/v1/chat/completions", null, Array.Empty<string>(), "{}");
+        var diagnostic = new CacheMissDiagnostic(canonical, "ABCDEF", "/tmp/mocks");
+
+        diagnostic.ExpectedCanonicalRequest.Should().Be(canonical);
+        diagnostic.ComputedKey.Should().Be("ABCDEF");
+        diagnostic.CachePath.Should().Be("/tmp/mocks");
+    }
+}

--- a/Augustus/Augustus.Tests/RequestKeyTests.cs
+++ b/Augustus/Augustus.Tests/RequestKeyTests.cs
@@ -49,6 +49,35 @@ public class RequestKeyTests
     }
 
     [Fact]
+    public void RequestKey_DifferentListInstances_SameContents_AreEqual()
+    {
+        var a = new RequestKey("POST", "/v1/x", null, new List<string> { "i1", "i2" }, "{}");
+        var b = new RequestKey("POST", "/v1/x", null, new[] { "i1", "i2" }, "{}");
+
+        a.Equals(b).Should().BeTrue();
+        a.GetHashCode().Should().Be(b.GetHashCode());
+    }
+
+    [Fact]
+    public void RequestKey_DifferentInstructionContents_AreNotEqual()
+    {
+        var a = new RequestKey("POST", "/v1/x", null, new[] { "i1" }, "{}");
+        var b = new RequestKey("POST", "/v1/x", null, new[] { "i2" }, "{}");
+
+        a.Equals(b).Should().BeFalse();
+    }
+
+    [Fact]
+    public void CanonicalRequest_DifferentListInstances_SameContents_AreEqual()
+    {
+        var a = new CanonicalRequest("POST", "/v1/x", null, new List<string> { "i1", "i2" }, "{}");
+        var b = new CanonicalRequest("POST", "/v1/x", null, new[] { "i1", "i2" }, "{}");
+
+        a.Equals(b).Should().BeTrue();
+        a.GetHashCode().Should().Be(b.GetHashCode());
+    }
+
+    [Fact]
     public void CacheMissDiagnostic_ExposesExpectedIdentity()
     {
         var canonical = new CanonicalRequest("POST", "/v1/chat/completions", null, Array.Empty<string>(), "{}");

--- a/Augustus/Augustus.Tests/RequestKeyTransformTests.cs
+++ b/Augustus/Augustus.Tests/RequestKeyTransformTests.cs
@@ -1,0 +1,104 @@
+using System.Text;
+using Augustus;
+using FluentAssertions;
+
+namespace Augustus.Tests;
+
+public class RequestKeyTransformTests
+{
+    private static byte[] Body(string s) => Encoding.UTF8.GetBytes(s);
+
+    [Fact]
+    public void AzureNormalization_DifferentDeployments_ProduceSameKey()
+    {
+        var rules = new CacheKeyRules { NormalizeAzureOpenAIDeployment = true };
+
+        var prod = RequestKeyFactory.Create(
+            "POST", "/openai/deployments/gpt-4-prod/chat/completions", "?api-version=2024-06-01",
+            Body("{\"model\":\"gpt-4\"}"), null, rules);
+        var dev = RequestKeyFactory.Create(
+            "POST", "/openai/deployments/gpt-4-dev-westus/chat/completions", "?api-version=2024-06-01",
+            Body("{\"model\":\"gpt-4\"}"), null, rules);
+
+        dev.Hash.Should().Be(prod.Hash);
+        prod.Canonical.Path.Should().Be("/openai/deployments/__DEPLOYMENT__/chat/completions");
+    }
+
+    [Fact]
+    public void AzureNormalization_Disabled_DeploymentRenameChangesKey()
+    {
+        var a = RequestKeyFactory.Create(
+            "POST", "/openai/deployments/a/chat/completions", null, Body("{}"), null, null);
+        var b = RequestKeyFactory.Create(
+            "POST", "/openai/deployments/b/chat/completions", null, Body("{}"), null, null);
+
+        a.Hash.Should().NotBe(b.Hash);
+    }
+
+    [Fact]
+    public void RequestKeyTransform_RewritesPath_AffectsKey()
+    {
+        var rules = new CacheKeyRules
+        {
+            RequestKeyTransform = k => k with { Path = "/normalized" }
+        };
+
+        var one = RequestKeyFactory.Create("GET", "/v1/a", null, Array.Empty<byte>(), null, rules);
+        var two = RequestKeyFactory.Create("GET", "/v1/b", null, Array.Empty<byte>(), null, rules);
+
+        one.Hash.Should().Be(two.Hash);
+        one.Canonical.Path.Should().Be("/normalized");
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void RecomputeFromCanonical_EqualsCreateHash_ForJustWrittenFixture(bool azure)
+    {
+        // The whole renameable-fixture feature rests on this invariant: a fixture written
+        // via Create resolves byte-identically when matched via its stored CanonicalRequest.
+        var rules = new CacheKeyRules { NormalizeAzureOpenAIDeployment = azure };
+        var created = RequestKeyFactory.Create(
+            "POST", "/openai/deployments/prod/chat/completions", "?api-version=2024-06-01",
+            Body("{\"model\":\"gpt-4\",\"messages\":[{\"role\":\"user\",\"content\":\"hello \\u00e9\"}]}"),
+            new[] { "be terse" }, rules);
+
+        var recomputed = RequestKeyFactory.ComputeKeyFromCanonical(created.Canonical, rules);
+
+        recomputed.Should().Be(created.Hash);
+    }
+
+    [Fact]
+    public async Task EnablingAzureNormalization_ReBaselinesExistingFixture_ZeroUpstream()
+    {
+        var cacheDir = Path.Combine(Path.GetTempPath(), $"augustus-rekey-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(cacheDir);
+        try
+        {
+            // Fixture was recorded under the OLD rules (no normalization), deployment "prod".
+            var legacy = RequestKeyFactory.Create(
+                "POST", "/openai/deployments/prod/chat/completions", "?api-version=2024-06-01",
+                Body("{\"model\":\"gpt-4\"}"), null, null);
+
+            var fileManager = new APISimulator.FileManager(cacheDir);
+            await fileManager.CacheResponseAsync(legacy.Hash, "{\"id\":\"rebaselined\"}",
+                "PROXY", new List<string>(), normalized: false, legacy.Canonical);
+
+            // Rules change: deployment-agnostic normalization is now enabled, and the
+            // upstream uses a renamed deployment. No API key, no proxy — pure disk match.
+            var normRules = new CacheKeyRules { NormalizeAzureOpenAIDeployment = true };
+            var incoming = RequestKeyFactory.Create(
+                "POST", "/openai/deployments/prod-eastus2/chat/completions", "?api-version=2024-06-01",
+                Body("{\"model\":\"gpt-4\"}"), null, normRules);
+
+            var fresh = new APISimulator.FileManager(cacheDir);
+            var entry = await fresh.ResolveEntryAsync(
+                incoming.Hash,
+                c => RequestKeyFactory.ComputeKeyFromCanonical(c, normRules));
+
+            entry.Should().NotBeNull();
+            entry!.Response.Should().Contain("rebaselined");
+        }
+        finally { Directory.Delete(cacheDir, true); }
+    }
+}

--- a/Augustus/Augustus.Tests/RequestKeyTransformTests.cs
+++ b/Augustus/Augustus.Tests/RequestKeyTransformTests.cs
@@ -25,6 +25,68 @@ public class RequestKeyTransformTests
     }
 
     [Fact]
+    public void AzureNormalization_StripsModelFieldFromBody_BodyOnlyDeploymentRenameMatches()
+    {
+        // The Azure OpenAI deployment name appears in TWO places in a typical request:
+        // the URL path AND the body's top-level "model" property. A region rename that
+        // updates BOTH must still hash identically once NormalizeAzureOpenAIDeployment is on.
+        var rules = new CacheKeyRules { NormalizeAzureOpenAIDeployment = true };
+
+        var before = RequestKeyFactory.Create(
+            "POST", "/openai/deployments/gpt-4-dev/chat/completions", "?api-version=2024-06-01",
+            Body("{\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}],\"model\":\"gpt-4-dev\"}"),
+            null, rules);
+        var after = RequestKeyFactory.Create(
+            "POST", "/openai/deployments/gpt-4-eus2-dev/chat/completions", "?api-version=2024-06-01",
+            Body("{\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}],\"model\":\"gpt-4-eus2-dev\"}"),
+            null, rules);
+
+        after.Hash.Should().Be(before.Hash,
+            "deployment-name rename in BOTH path and body must reduce to the same key under NormalizeAzureOpenAIDeployment");
+        before.Canonical.NormalizedBody.Should().Contain("\"model\":\"__DEPLOYMENT__\"");
+    }
+
+    [Fact]
+    public void AzureNormalization_BodyWithoutTopLevelModel_LeavesBodyAlone()
+    {
+        // Defensive: the body normalization only touches a TOP-LEVEL "model" property
+        // so requests without one (or with model nested deeper) hash identically to the
+        // pre-PR behavior when paths match.
+        var rules = new CacheKeyRules { NormalizeAzureOpenAIDeployment = true };
+
+        var noModel = RequestKeyFactory.Create(
+            "POST", "/openai/deployments/x/foo", null,
+            Body("{\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}]}"),
+            null, rules);
+
+        noModel.Canonical.NormalizedBody.Should().NotContain("__DEPLOYMENT__");
+    }
+
+    [Fact]
+    public void AzureNormalization_RecomputeFromCanonical_BodyModelFieldStillNormalized()
+    {
+        // Round-trip guarantee: a fixture's stored canonical body (which retains the
+        // original "model" value) must produce the same key as a fresh request under
+        // a different deployment name when both go through NormalizeAzureOpenAIDeployment.
+        var rules = new CacheKeyRules { NormalizeAzureOpenAIDeployment = true };
+
+        var recorded = RequestKeyFactory.Create(
+            "POST", "/openai/deployments/gpt-4-dev/chat/completions", "?api-version=2024-06-01",
+            Body("{\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}],\"model\":\"gpt-4-dev\"}"),
+            null, rules: null); // recorded WITHOUT normalization (legacy fixture path)
+
+        var recomputed = RequestKeyFactory.ComputeKeyFromCanonical(recorded.Canonical, rules);
+
+        var liveRequest = RequestKeyFactory.Create(
+            "POST", "/openai/deployments/gpt-4-eus2-dev/chat/completions", "?api-version=2024-06-01",
+            Body("{\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}],\"model\":\"gpt-4-eus2-dev\"}"),
+            null, rules);
+
+        liveRequest.Hash.Should().Be(recomputed,
+            "rekey computing key from a legacy canonical must produce the same hash as a live request under new rules");
+    }
+
+    [Fact]
     public void AzureNormalization_Disabled_DeploymentRenameChangesKey()
     {
         var a = RequestKeyFactory.Create(

--- a/Augustus/Augustus/APISimulator.cs
+++ b/Augustus/Augustus/APISimulator.cs
@@ -57,7 +57,13 @@ public sealed partial class APISimulator : IAsyncDisposable
             options.ResetCacheFolderPathExplicitFlag();
         }
 
-        fileManager = new FileManager(options.CacheFolderPath);
+        fileManager = new FileManager(options.CacheFolderPath)
+        {
+            // Make per-scenario stale removal in ClearTestContext honor the same option
+            // that controls end-of-run stale removal. Without this, AutoRemoveStaleCache
+            // = false is silently violated every time a scenario hits ClearTestContext.
+            AutoRemoveStaleCache = options.AutoRemoveStaleCache,
+        };
         instructionsContainer = new InstructionsContainer(apiName);
 
         routingHandler = new RoutingRequestHandler(this);

--- a/Augustus/Augustus/APISimulatorOptions.cs
+++ b/Augustus/Augustus/APISimulatorOptions.cs
@@ -125,6 +125,62 @@ public sealed class APISimulatorOptions
         }
     }
 
+    /// <summary>
+    /// Gets or sets a transform applied to the <see cref="RequestKey"/> before hashing and
+    /// matching. Use it to strip or rewrite volatile parts of the request (path segments,
+    /// query values) so incidental changes do not invalidate committed fixtures. The same
+    /// transform is applied to incoming requests and re-applied to each fixture's stored
+    /// <see cref="CanonicalRequest"/>, so a keying-rule change re-baselines with zero
+    /// upstream calls. Must be pure, deterministic, and idempotent (<c>f(f(x)) == f(x)</c>).
+    /// </summary>
+    public Func<RequestKey, RequestKey>? RequestKeyTransform { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the volatile Azure OpenAI deployment path
+    /// segment (<c>/openai/deployments/{deployment}/…</c>) is replaced with a constant
+    /// before hashing, making cache keys deployment- and region-agnostic. Default is
+    /// <c>false</c>. Applied before <see cref="RequestKeyTransform"/>.
+    /// </summary>
+    public bool NormalizeAzureOpenAIDeployment { get; set; }
+
+    /// <summary>
+    /// Gets or sets a callback invoked on every cache miss with the canonical request and
+    /// computed key Augustus expected. Use it to discover the exact identity needed to
+    /// author or rename a fixture by hand when the upstream API is unavailable.
+    /// </summary>
+    public Action<CacheMissDiagnostic>? OnCacheMiss { get; set; }
+
+    private readonly List<string> _ignoredHeaders = new();
+    private readonly List<string> _ignoredQueryParameters = new();
+
+    /// <summary>
+    /// Gets a list of request header names excluded from the request forwarded to the AI
+    /// model when generating a response. Cache identity never includes headers; use this
+    /// to keep volatile headers out of the AI prompt so they do not influence generation.
+    /// </summary>
+    public IList<string> IgnoredHeaders => _ignoredHeaders;
+
+    /// <summary>
+    /// Gets a list of query-string parameter names removed before the cache key is
+    /// computed, so volatile parameters (cache-busters, timestamps) do not invalidate
+    /// committed fixtures.
+    /// </summary>
+    public IList<string> IgnoredQueryParameters => _ignoredQueryParameters;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether JSON body properties whose value is
+    /// <c>null</c> are removed before the cache key is computed, so an explicit-null vs.
+    /// omitted-property difference does not churn the cache. Default is <c>false</c>.
+    /// </summary>
+    public bool StripNullBodyProperties { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether only <c>messages[].content</c> participates
+    /// in the cache key, so cosmetic changes to other body fields (temperature, metadata)
+    /// do not churn caches. Default is <c>false</c>.
+    /// </summary>
+    public bool HashMessagesContentOnly { get; set; }
+
     private readonly List<string> _dynamicContentFields = new();
 
     /// <summary>
@@ -137,6 +193,18 @@ public sealed class APISimulatorOptions
     /// Add items via the <see cref="ICollection{T}.Add"/> method on the returned list.
     /// </remarks>
     public IList<string> DynamicContentFields => _dynamicContentFields;
+
+    /// <summary>
+    /// Builds the normalization rules applied when computing and matching cache keys.
+    /// The default (no transform, no knobs) reproduces the historical key byte-for-byte.
+    /// </summary>
+    internal CacheKeyRules BuildCacheKeyRules() => CacheKeyRules.From(
+        _dynamicContentFields,
+        _ignoredQueryParameters,
+        RequestKeyTransform,
+        NormalizeAzureOpenAIDeployment,
+        StripNullBodyProperties,
+        HashMessagesContentOnly);
 
     /// <summary>
     /// Validates that all required configuration is present and correct.

--- a/Augustus/Augustus/APISimulatorOptions.cs
+++ b/Augustus/Augustus/APISimulatorOptions.cs
@@ -181,6 +181,27 @@ public sealed class APISimulatorOptions
     /// </summary>
     public bool HashMessagesContentOnly { get; set; }
 
+    /// <summary>
+    /// On cache HIT for a legacy fixture (no <see cref="CanonicalRequest"/>), rewrite the
+    /// file in place with the freshly computed canonical request so it can later be
+    /// renamed offline via <see cref="CacheMaintenance.Rekey"/>. The on-disk filename is
+    /// not changed by the backfill; only the JSON body gains the missing
+    /// <c>CanonicalRequest</c> block. Idempotent — a fixture that already has a
+    /// CanonicalRequest is never rewritten. Default is <c>false</c>, preserving
+    /// byte-identical behavior for legacy fixtures.
+    /// </summary>
+    /// <remarks>
+    /// Use this for one-shot migration of pre-canonical-request fixtures: enable it,
+    /// run the existing test suite in proxy mode with the historical keying rules so
+    /// every request still hits the legacy filename, and the backfill embeds
+    /// CanonicalRequest into each fixture without any upstream API calls. After the
+    /// migration pass, disable it and enable the keying-rule knobs you want
+    /// (<see cref="NormalizeAzureOpenAIDeployment"/>, <see cref="RequestKeyTransform"/>,
+    /// etc.), then call <see cref="CacheMaintenance.Rekey"/> to rename files under the
+    /// new rules.
+    /// </remarks>
+    public bool BackfillLegacyCanonicalRequest { get; set; }
+
     private readonly List<string> _dynamicContentFields = new();
 
     /// <summary>

--- a/Augustus/Augustus/CacheFiles.cs
+++ b/Augustus/Augustus/CacheFiles.cs
@@ -1,0 +1,22 @@
+namespace Augustus;
+
+internal static class CacheFiles
+{
+    /// <summary>
+    /// Enumerates the <c>*.json</c> fixture files in <paramref name="path"/>, returning an
+    /// empty array if the directory is absent or vanishes mid-enumeration.
+    /// </summary>
+    public static string[] JsonFiles(string path)
+    {
+        if (!Directory.Exists(path))
+            return Array.Empty<string>();
+        try
+        {
+            return Directory.GetFiles(path, "*.json");
+        }
+        catch (DirectoryNotFoundException)
+        {
+            return Array.Empty<string>();
+        }
+    }
+}

--- a/Augustus/Augustus/CacheKeyBodyNormalizer.cs
+++ b/Augustus/Augustus/CacheKeyBodyNormalizer.cs
@@ -27,6 +27,13 @@ internal static class CacheKeyBodyNormalizer
     /// result is serialized with <see cref="SerializerOptions"/>. Non-JSON bodies are returned unchanged.
     /// </summary>
     public static byte[] PrepareBodyForCacheKey(byte[] body, IReadOnlyCollection<string>? propertyNames)
+        => PrepareBodyForCacheKey(body, propertyNames, stripNullProperties: false, hashMessagesContentOnly: false);
+
+    public static byte[] PrepareBodyForCacheKey(
+        byte[] body,
+        IReadOnlyCollection<string>? propertyNames,
+        bool stripNullProperties,
+        bool hashMessagesContentOnly)
     {
         propertyNames ??= Array.Empty<string>();
         if (body.Length == 0)
@@ -61,6 +68,20 @@ internal static class CacheKeyBodyNormalizer
             {
                 NormalizeNewlines(canonical);
             }
+
+            if (hashMessagesContentOnly && canonical is JsonObject obj && obj["messages"] is JsonArray msgs)
+            {
+                var reduced = new JsonArray();
+                foreach (var m in msgs)
+                {
+                    if (m is JsonObject mo && mo.TryGetPropertyValue("content", out var content))
+                        reduced.Add(content is null ? null : JsonNode.Parse(content.ToJsonString()));
+                }
+                canonical = new JsonObject { ["messages"] = reduced };
+            }
+
+            if (stripNullProperties)
+                StripNulls(canonical);
 
             if (propertyNames.Count > 0)
                 NormalizeNode(canonical, propertyNames);
@@ -133,6 +154,31 @@ internal static class CacheKeyBodyNormalizer
                 return newArr;
             default:
                 return DetachCopy(node);
+        }
+    }
+
+    /// <summary>
+    /// Recursively removes object properties whose value is JSON <c>null</c> so that an
+    /// explicit-null vs. omitted-property difference does not churn the cache key.
+    /// </summary>
+    private static void StripNulls(JsonNode? node)
+    {
+        switch (node)
+        {
+            case JsonObject obj:
+                foreach (var key in obj.Select(kvp => kvp.Key).ToList())
+                {
+                    var child = obj[key];
+                    if (child is null)
+                        obj.Remove(key);
+                    else
+                        StripNulls(child);
+                }
+                break;
+            case JsonArray arr:
+                foreach (var item in arr)
+                    StripNulls(item);
+                break;
         }
     }
 

--- a/Augustus/Augustus/CacheKeyComputer.cs
+++ b/Augustus/Augustus/CacheKeyComputer.cs
@@ -1,12 +1,12 @@
-using System.Security.Cryptography;
-using System.Text;
-
 namespace Augustus;
 
+/// <summary>
+/// Computes the cache key for a request. Thin façade over <see cref="RequestKeyFactory"/>;
+/// the default (no rules) path is byte-identical to the historical key so existing
+/// fixtures keep resolving without a rekey.
+/// </summary>
 internal static class CacheKeyComputer
 {
-    private static readonly byte[] Separator = Encoding.UTF8.GetBytes("|");
-
     public static string ComputeCacheKey(string method, string path, string? queryString, byte[] body, List<string>? instructions = null, IEnumerable<string>? dynamicContentFields = null)
     {
         return ComputeCacheKey(method, path, queryString, body, out _, instructions, dynamicContentFields);
@@ -14,30 +14,15 @@ internal static class CacheKeyComputer
 
     public static string ComputeCacheKey(string method, string path, string? queryString, byte[] body, out byte[] materializedBody, List<string>? instructions = null, IEnumerable<string>? dynamicContentFields = null)
     {
-        using var sha = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
-        sha.AppendData(Encoding.UTF8.GetBytes(method));
-        sha.AppendData(Separator);
-        sha.AppendData(Encoding.UTF8.GetBytes(path));
-        sha.AppendData(Separator);
-        sha.AppendData(Encoding.UTF8.GetBytes(queryString ?? string.Empty));
-        sha.AppendData(Separator);
-
-        var materializedFields = dynamicContentFields as IReadOnlyCollection<string>
+        var fields = dynamicContentFields as IReadOnlyCollection<string>
             ?? (dynamicContentFields != null ? dynamicContentFields.ToArray() : null);
-        materializedBody = CacheKeyBodyNormalizer.PrepareBodyForCacheKey(
-            body,
-            materializedFields ?? (IReadOnlyCollection<string>)Array.Empty<string>());
-        sha.AppendData(materializedBody);
-        if (instructions is { Count: > 0 })
-        {
-            sha.AppendData(Separator);
-            sha.AppendData(Encoding.UTF8.GetBytes(instructions.Count.ToString()));
-            foreach (var instruction in instructions)
-            {
-                sha.AppendData(Separator);
-                sha.AppendData(Encoding.UTF8.GetBytes(instruction));
-            }
-        }
-        return Convert.ToHexString(sha.GetHashAndReset());
+
+        var rules = fields is { Count: > 0 }
+            ? new CacheKeyRules { DynamicContentFields = fields }
+            : CacheKeyRules.Legacy;
+
+        var result = RequestKeyFactory.Create(method, path, queryString, body, instructions, rules);
+        materializedBody = result.MaterializedBody;
+        return result.Hash;
     }
 }

--- a/Augustus/Augustus/CacheMaintenance.cs
+++ b/Augustus/Augustus/CacheMaintenance.cs
@@ -1,0 +1,187 @@
+using System.Text.Json;
+
+namespace Augustus;
+
+/// <summary>
+/// Offline maintenance for committed cache fixtures. Recomputes file names from each
+/// fixture's stored <see cref="CanonicalRequest"/> under a (possibly new) keying rule, so
+/// adopting a new rule re-baselines fixtures with zero upstream API calls.
+/// </summary>
+public static class CacheMaintenance
+{
+    /// <summary>
+    /// Recomputes the cache key for every fixture in <paramref name="cachePath"/> from its
+    /// stored <see cref="CanonicalRequest"/> and renames the file to <c>{key}.json</c>.
+    /// Files without a <see cref="CanonicalRequest"/> are skipped (their identity is
+    /// unknowable). Collisions are reported and never overwritten.
+    /// </summary>
+    /// <param name="cachePath">The cache folder to rekey.</param>
+    /// <param name="options">Keying rules and behavior (recursion, dry-run).</param>
+    /// <remarks>
+    /// Renames execute in directory order with no overwrite. A key <em>cycle</em>
+    /// (fixture A's new key is B's current file name and vice-versa) is reported in
+    /// <see cref="RekeyResult.Conflicts"/> and left untouched on the first pass; re-run
+    /// <see cref="Rekey"/> while <see cref="RekeyResult.Conflicts"/> is non-empty to drain
+    /// such cycles. Data is never overwritten.
+    /// </remarks>
+    public static RekeyResult Rekey(string cachePath, RekeyOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(cachePath);
+        ArgumentNullException.ThrowIfNull(options);
+
+        var rules = options.ToCacheKeyRules();
+        var scanned = 0;
+        var renamed = 0;
+        var skipped = 0;
+        var conflicts = new List<string>();
+
+        foreach (var dir in EnumerateDirectories(cachePath, options.Recursive))
+        {
+            var files = CacheFiles.JsonFiles(dir);
+
+            // Plan renames first so collisions can be detected without mutating the disk.
+            var plan = new List<(string source, string targetName)>();
+            var targetCounts = new Dictionary<string, int>(StringComparer.Ordinal);
+
+            foreach (var file in files)
+            {
+                scanned++;
+                APISimulator.CacheEntry? entry;
+                try
+                {
+                    entry = JsonSerializer.Deserialize<APISimulator.CacheEntry>(File.ReadAllText(file));
+                }
+                catch (Exception ex) when (ex is JsonException or IOException or UnauthorizedAccessException)
+                {
+                    skipped++;
+                    continue;
+                }
+
+                if (entry?.CanonicalRequest is not { } canonical)
+                {
+                    skipped++;
+                    continue;
+                }
+
+                var targetName = RequestKeyFactory.ComputeKeyFromCanonical(canonical, rules) + ".json";
+                plan.Add((file, targetName));
+                targetCounts[targetName] = targetCounts.GetValueOrDefault(targetName) + 1;
+            }
+
+            foreach (var (source, targetName) in plan)
+            {
+                var sourceName = Path.GetFileName(source);
+                if (string.Equals(sourceName, targetName, StringComparison.Ordinal))
+                    continue; // already correctly keyed
+
+                if (targetCounts[targetName] > 1)
+                {
+                    conflicts.Add(source);
+                    continue;
+                }
+
+                var target = Path.Combine(dir, targetName);
+                // Only safe if the target slot is free, or it is a stale file that itself
+                // will be moved away by this same plan.
+                if (File.Exists(target)
+                    && !plan.Any(p => string.Equals(Path.GetFileName(p.source), targetName, StringComparison.Ordinal)
+                                      && !string.Equals(p.targetName, targetName, StringComparison.Ordinal)))
+                {
+                    conflicts.Add(source);
+                    continue;
+                }
+
+                if (!options.DryRun)
+                {
+                    try
+                    {
+                        File.Move(source, target, overwrite: false);
+                    }
+                    catch (IOException)
+                    {
+                        conflicts.Add(source);
+                        continue;
+                    }
+                }
+
+                renamed++;
+            }
+        }
+
+        return new RekeyResult(scanned, renamed, skipped, conflicts);
+    }
+
+    private static IEnumerable<string> EnumerateDirectories(string root, bool recursive)
+    {
+        if (!Directory.Exists(root))
+            yield break;
+
+        yield return root;
+        if (!recursive)
+            yield break;
+
+        foreach (var sub in Directory.EnumerateDirectories(root, "*", SearchOption.AllDirectories))
+            yield return sub;
+    }
+}
+
+/// <summary>
+/// Options controlling <see cref="CacheMaintenance.Rekey"/>. The keying rules must match
+/// the rules the simulator will use at run time for the rekey to be meaningful.
+/// </summary>
+public sealed class RekeyOptions
+{
+    private readonly List<string> _dynamicContentFields = new();
+    private readonly List<string> _ignoredQueryParameters = new();
+
+    /// <summary>Mirrors <see cref="APISimulatorOptions.RequestKeyTransform"/>.</summary>
+    public Func<RequestKey, RequestKey>? RequestKeyTransform { get; set; }
+
+    /// <summary>Mirrors <see cref="APISimulatorOptions.NormalizeAzureOpenAIDeployment"/>.</summary>
+    public bool NormalizeAzureOpenAIDeployment { get; set; }
+
+    /// <summary>Mirrors <see cref="APISimulatorOptions.DynamicContentFields"/>.</summary>
+    public IList<string> DynamicContentFields => _dynamicContentFields;
+
+    /// <summary>Mirrors <see cref="APISimulatorOptions.IgnoredQueryParameters"/>.</summary>
+    public IList<string> IgnoredQueryParameters => _ignoredQueryParameters;
+
+    /// <summary>Mirrors <see cref="APISimulatorOptions.StripNullBodyProperties"/>.</summary>
+    public bool StripNullBodyProperties { get; set; }
+
+    /// <summary>Mirrors <see cref="APISimulatorOptions.HashMessagesContentOnly"/>.</summary>
+    public bool HashMessagesContentOnly { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether per-context subdirectories are also rekeyed.
+    /// Default is <c>true</c>.
+    /// </summary>
+    public bool Recursive { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to report what would change without
+    /// renaming any files. Default is <c>false</c>.
+    /// </summary>
+    public bool DryRun { get; set; }
+
+    internal CacheKeyRules ToCacheKeyRules() => CacheKeyRules.From(
+        _dynamicContentFields,
+        _ignoredQueryParameters,
+        RequestKeyTransform,
+        NormalizeAzureOpenAIDeployment,
+        StripNullBodyProperties,
+        HashMessagesContentOnly);
+}
+
+/// <summary>
+/// The outcome of a <see cref="CacheMaintenance.Rekey"/> run.
+/// </summary>
+/// <param name="Scanned">Total fixture files inspected.</param>
+/// <param name="Renamed">Files renamed to their recomputed key.</param>
+/// <param name="Skipped">Files skipped (no <see cref="CanonicalRequest"/> or unreadable).</param>
+/// <param name="Conflicts">Source paths left untouched because renaming would overwrite another fixture.</param>
+public sealed record RekeyResult(
+    int Scanned,
+    int Renamed,
+    int Skipped,
+    IReadOnlyList<string> Conflicts);

--- a/Augustus/Augustus/CacheMaintenance.cs
+++ b/Augustus/Augustus/CacheMaintenance.cs
@@ -18,11 +18,11 @@ public static class CacheMaintenance
     /// <param name="cachePath">The cache folder to rekey.</param>
     /// <param name="options">Keying rules and behavior (recursion, dry-run).</param>
     /// <remarks>
-    /// Renames execute in directory order with no overwrite. A key <em>cycle</em>
-    /// (fixture A's new key is B's current file name and vice-versa) is reported in
-    /// <see cref="RekeyResult.Conflicts"/> and left untouched on the first pass; re-run
-    /// <see cref="Rekey"/> while <see cref="RekeyResult.Conflicts"/> is non-empty to drain
-    /// such cycles. Data is never overwritten.
+    /// Renames are two-phase per directory (every planned file moves to a unique temp name
+    /// first, then to its final key), so chains and cycles like <c>A→B, B→A</c> resolve in
+    /// a single pass. N→1 collisions (two fixtures recomputing to the same key) and
+    /// unreadable files are reported in <see cref="RekeyResult.Conflicts"/> /
+    /// <see cref="RekeyResult.Skipped"/> and never overwritten.
     /// </remarks>
     public static RekeyResult Rekey(string cachePath, RekeyOptions options)
     {
@@ -68,10 +68,11 @@ public static class CacheMaintenance
                 targetCounts[targetName] = targetCounts.GetValueOrDefault(targetName) + 1;
             }
 
+            // Filter the plan: drop already-correctly-keyed files and N→1 collisions.
+            var moves = new List<(string source, string targetName)>();
             foreach (var (source, targetName) in plan)
             {
-                var sourceName = Path.GetFileName(source);
-                if (string.Equals(sourceName, targetName, StringComparison.Ordinal))
+                if (string.Equals(Path.GetFileName(source), targetName, StringComparison.Ordinal))
                     continue; // already correctly keyed
 
                 if (targetCounts[targetName] > 1)
@@ -80,26 +81,54 @@ public static class CacheMaintenance
                     continue;
                 }
 
+                moves.Add((source, targetName));
+            }
+
+            // A planned target is only blocked if some existing file occupies its slot and
+            // isn't itself being moved away — predict that without touching disk so DryRun
+            // reports honestly and the two-phase rename has no surprises.
+            var plannedSourceNames = new HashSet<string>(
+                moves.Select(m => Path.GetFileName(m.source)!), StringComparer.Ordinal);
+
+            // Two-phase rename so chains and cycles (A→B, B→A) resolve in a single pass:
+            // every move first goes to a unique temp name, then to its final key.
+            var phase1 = new List<(string tempPath, string targetName, string sourceForReporting)>();
+            foreach (var (source, targetName) in moves)
+            {
                 var target = Path.Combine(dir, targetName);
-                // Only safe if the target slot is free, or it is a stale file that itself
-                // will be moved away by this same plan.
-                if (File.Exists(target)
-                    && !plan.Any(p => string.Equals(Path.GetFileName(p.source), targetName, StringComparison.Ordinal)
-                                      && !string.Equals(p.targetName, targetName, StringComparison.Ordinal)))
+                if (File.Exists(target) && !plannedSourceNames.Contains(targetName))
                 {
                     conflicts.Add(source);
                     continue;
                 }
 
+                var temp = Path.Combine(dir, $"{Guid.NewGuid():N}.rekey.tmp");
                 if (!options.DryRun)
                 {
                     try
                     {
-                        File.Move(source, target, overwrite: false);
+                        File.Move(source, temp, overwrite: false);
                     }
                     catch (IOException)
                     {
                         conflicts.Add(source);
+                        continue;
+                    }
+                }
+                phase1.Add((temp, targetName, source));
+            }
+
+            foreach (var (tempPath, targetName, sourceForReporting) in phase1)
+            {
+                if (!options.DryRun)
+                {
+                    try
+                    {
+                        File.Move(tempPath, Path.Combine(dir, targetName), overwrite: false);
+                    }
+                    catch (IOException)
+                    {
+                        conflicts.Add(sourceForReporting);
                         continue;
                     }
                 }

--- a/Augustus/Augustus/CacheMaintenance.cs
+++ b/Augustus/Augustus/CacheMaintenance.cs
@@ -128,7 +128,22 @@ public static class CacheMaintenance
                     }
                     catch (IOException)
                     {
-                        conflicts.Add(sourceForReporting);
+                        // Don't strand the fixture as *.rekey.tmp (invisible to *.json
+                        // scans on the next run): best-effort revert temp -> source. If
+                        // revert also fails, surface the temp path so the caller can
+                        // recover manually instead of silently losing the file.
+                        try
+                        {
+                            File.Move(tempPath, sourceForReporting, overwrite: false);
+                            conflicts.Add(sourceForReporting);
+                        }
+                        catch (IOException)
+                        {
+                            System.Diagnostics.Debug.WriteLine(
+                                $"Warning: Rekey could not revert {tempPath} to {sourceForReporting}; " +
+                                "manual recovery required.");
+                            conflicts.Add(tempPath);
+                        }
                         continue;
                     }
                 }

--- a/Augustus/Augustus/FileManager.cs
+++ b/Augustus/Augustus/FileManager.cs
@@ -261,7 +261,15 @@ public partial class APISimulator
         {
             var direct = await ReadCachedEntryAsync(primaryKey).ConfigureAwait(false);
             if (direct?.Response is { Length: > 0 })
-                return new ResolveResult(direct, primaryKey);
+            {
+                // For entries that carry a CanonicalRequest, verify it really matches the
+                // requested key before serving — otherwise a stale/hand-authored file whose
+                // label happens to equal another request's hash would return the wrong
+                // response. Legacy entries (null canonical) are trusted by filename for
+                // back-compat.
+                if (direct.CanonicalRequest is null || recompute(direct.CanonicalRequest) == primaryKey)
+                    return new ResolveResult(direct, primaryKey);
+            }
 
             // Built once per effective cache path (fixtures are expected to exist before the
             // first request); our own writes patch it incrementally, context switches drop it.
@@ -352,7 +360,16 @@ public partial class APISimulator
                     {
                         try
                         {
-                            index[recompute(canonical)] = label;
+                            var key = recompute(canonical);
+                            // First-wins + warn: silently overwriting would return an
+                            // arbitrary response depending on directory-enumeration order.
+                            if (!index.TryAdd(key, label) && index[key] != label)
+                            {
+                                System.Diagnostics.Debug.WriteLine(
+                                    $"Warning: cache fixture {file} recomputes to key {key} " +
+                                    $"already claimed by {index[key]}.json — skipping. " +
+                                    "Remove or re-normalize the duplicate fixture.");
+                            }
                         }
                         catch (Exception ex)
                         {

--- a/Augustus/Augustus/FileManager.cs
+++ b/Augustus/Augustus/FileManager.cs
@@ -15,6 +15,13 @@ public partial class APISimulator
         private ConcurrentDictionary<string, byte> _touchedHashes = new();
         private string? _currentTestContext;
 
+        /// <summary>
+        /// Mirrors <see cref="APISimulatorOptions.AutoRemoveStaleCache"/> so per-scenario
+        /// context cleanup honors the option. Default <c>true</c> preserves historical
+        /// behavior for callers that construct a <see cref="FileManager"/> directly.
+        /// </summary>
+        internal bool AutoRemoveStaleCache { get; set; } = true;
+
         // Content-addressed index per effective cache path: recomputed key -> file label
         // (filename without extension). Lets renamed / hand-authored / rule-changed fixtures
         // resolve when the fast {key}.json probe misses. Built once per path (fixtures are
@@ -58,14 +65,19 @@ public partial class APISimulator
         }
 
         /// <summary>
-        /// Clears the current test context. Runs scoped stale entry removal for the
-        /// context's subdirectory before clearing.
+        /// Clears the current test context. When <see cref="AutoRemoveStaleCache"/> is
+        /// <c>true</c>, runs scoped stale entry removal for the context's subdirectory
+        /// before clearing — fixtures not touched during the scenario are deleted on disk.
+        /// When <c>false</c>, the on-disk fixtures are preserved verbatim; this is the
+        /// right setting for committed __mocks__/ trees where a scenario miss must never
+        /// silently delete the file you're trying to debug.
         /// </summary>
         public void ClearTestContext()
         {
             if (_currentTestContext != null)
             {
-                RemoveStaleEntriesFromPath(CurrentCachePath);
+                if (AutoRemoveStaleCache)
+                    RemoveStaleEntriesFromPath(CurrentCachePath);
                 _currentTestContext = null;
                 _touchedHashes.Clear();
                 InvalidateIndex();

--- a/Augustus/Augustus/FileManager.cs
+++ b/Augustus/Augustus/FileManager.cs
@@ -343,7 +343,13 @@ public partial class APISimulator
                     return existing;
 
                 var index = new ConcurrentDictionary<string, string>();
-                foreach (var file in CacheFiles.JsonFiles(path))
+                // Sort so first-wins on key collision is deterministic across machines —
+                // Directory.GetFiles enumeration order is unspecified, and the only signal
+                // for a duplicate-key fixture is a Debug.WriteLine, so an arbitrary winner
+                // would silently shift cache hits between runs.
+                var files = CacheFiles.JsonFiles(path);
+                Array.Sort(files, StringComparer.Ordinal);
+                foreach (var file in files)
                 {
                     var label = Path.GetFileNameWithoutExtension(file);
                     CacheEntry? entry;

--- a/Augustus/Augustus/FileManager.cs
+++ b/Augustus/Augustus/FileManager.cs
@@ -246,9 +246,22 @@ public partial class APISimulator
         /// </summary>
         public async Task<CacheEntry?> ResolveEntryAsync(string primaryKey, Func<CanonicalRequest, string> recompute)
         {
+            var result = await ResolveEntryWithLabelAsync(primaryKey, recompute).ConfigureAwait(false);
+            return result?.Entry;
+        }
+
+        /// <summary>
+        /// Same as <see cref="ResolveEntryAsync"/> but also returns the on-disk file label
+        /// (filename without extension) that produced the match. The label is needed by
+        /// callers that want to rewrite the fixture in place — e.g.
+        /// <see cref="BackfillCanonicalAsync"/> for the
+        /// <see cref="APISimulatorOptions.BackfillLegacyCanonicalRequest"/> flow.
+        /// </summary>
+        public async Task<ResolveResult?> ResolveEntryWithLabelAsync(string primaryKey, Func<CanonicalRequest, string> recompute)
+        {
             var direct = await ReadCachedEntryAsync(primaryKey).ConfigureAwait(false);
             if (direct?.Response is { Length: > 0 })
-                return direct;
+                return new ResolveResult(direct, primaryKey);
 
             // Built once per effective cache path (fixtures are expected to exist before the
             // first request); our own writes patch it incrementally, context switches drop it.
@@ -261,7 +274,7 @@ public partial class APISimulator
                 {
                     // Track by the on-disk label so stale-removal keeps renamed fixtures.
                     _touchedHashes.TryAdd(label, 0);
-                    return matched;
+                    return new ResolveResult(matched, label);
                 }
 
                 // Label points at a file that was deleted/renamed mid-run: self-heal so the
@@ -270,6 +283,30 @@ public partial class APISimulator
             }
 
             return null;
+        }
+
+        /// <summary>
+        /// One-shot in-place rewrite: if the fixture at <paramref name="label"/> has no
+        /// <see cref="CanonicalRequest"/>, set it to <paramref name="canonical"/> and
+        /// reserialize. Idempotent — a fixture that already carries a CanonicalRequest is
+        /// left untouched and the method returns <c>false</c>. The filename is not changed;
+        /// use <see cref="CacheMaintenance.Rekey"/> afterwards to apply a new keying rule.
+        /// </summary>
+        /// <returns><c>true</c> if the file was rewritten, <c>false</c> if it was skipped (idempotent no-op or unreadable).</returns>
+        public async Task<bool> BackfillCanonicalAsync(string label, CanonicalRequest canonical)
+        {
+            ArgumentNullException.ThrowIfNull(canonical);
+            ValidateFileName($"{label}.json");
+
+            var json = await ReadFromFileAsync($"{label}.json").ConfigureAwait(false);
+            var entry = DeserializeEntry(json);
+            if (entry is null || entry.CanonicalRequest is not null)
+                return false;
+
+            entry.CanonicalRequest = canonical;
+            var updated = JsonSerializer.Serialize(entry, CacheSerializerOptions);
+            await WriteToFileAsync($"{label}.json", updated).ConfigureAwait(false);
+            return true;
         }
 
         private static CacheEntry? DeserializeEntry(string? json)
@@ -427,4 +464,13 @@ public partial class APISimulator
         /// </summary>
         public CanonicalRequest? CanonicalRequest { get; set; }
     }
+
+    /// <summary>
+    /// Outcome of <see cref="FileManager.ResolveEntryWithLabelAsync"/>: the matched
+    /// <see cref="CacheEntry"/> and the on-disk file label (filename without extension)
+    /// that produced the match. Use the label for in-place rewrites that must target the
+    /// actual fixture file (e.g. legacy <see cref="CanonicalRequest"/> backfill) instead
+    /// of the request's computed primary key.
+    /// </summary>
+    internal sealed record ResolveResult(CacheEntry Entry, string Label);
 }

--- a/Augustus/Augustus/FileManager.cs
+++ b/Augustus/Augustus/FileManager.cs
@@ -15,6 +15,15 @@ public partial class APISimulator
         private ConcurrentDictionary<string, byte> _touchedHashes = new();
         private string? _currentTestContext;
 
+        // Content-addressed index per effective cache path: recomputed key -> file label
+        // (filename without extension). Lets renamed / hand-authored / rule-changed fixtures
+        // resolve when the fast {key}.json probe misses. Built once per path (fixtures are
+        // expected to exist before the first request); our own writes patch it incrementally;
+        // dropped on context/base-path changes. Fixtures added externally mid-run are not
+        // picked up until the next context switch — edit fixtures between runs.
+        private readonly ConcurrentDictionary<string, ConcurrentDictionary<string, string>> _indexByCachePath = new();
+        private readonly object _indexLock = new();
+
         public FileManager(string cacheFolderPath)
         {
             this.cacheFolderPath = cacheFolderPath;
@@ -40,6 +49,7 @@ public partial class APISimulator
                 throw new ArgumentException("Test name cannot be null or whitespace.", nameof(testName));
             _currentTestContext = testName;
             _touchedHashes.Clear();
+            InvalidateIndex();
             var contextPath = CurrentCachePath;
             if (!Directory.Exists(contextPath))
             {
@@ -58,6 +68,7 @@ public partial class APISimulator
                 RemoveStaleEntriesFromPath(CurrentCachePath);
                 _currentTestContext = null;
                 _touchedHashes.Clear();
+                InvalidateIndex();
             }
         }
 
@@ -106,6 +117,7 @@ public partial class APISimulator
                 throw new ArgumentException("Cache base path cannot be null or whitespace.", nameof(newBasePath));
             cacheFolderPath = newBasePath;
             _touchedHashes.Clear();
+            InvalidateIndex();
             EnsureCacheFolderExists();
 
             // If a test context is active, ensure its subdirectory also exists under the new base
@@ -171,7 +183,7 @@ public partial class APISimulator
         public Task CacheResponseAsync(string requestHash, string response, string originalRequest, List<string> instructions)
             => CacheResponseAsync(requestHash, response, originalRequest, instructions, normalized: false);
 
-        public async Task CacheResponseAsync(string requestHash, string response, string originalRequest, List<string> instructions, bool normalized)
+        public async Task CacheResponseAsync(string requestHash, string response, string originalRequest, List<string> instructions, bool normalized, CanonicalRequest? canonical = null)
         {
             ValidateFileName(requestHash);
 
@@ -182,12 +194,18 @@ public partial class APISimulator
                 OriginalRequest = SensitiveDataSanitizer.SanitizeSensitiveValues(originalRequest),
                 Instructions = instructions.Select(SensitiveDataSanitizer.SanitizeSensitiveValues).ToList(),
                 Timestamp = DateTime.UtcNow,
-                Normalized = normalized
+                Normalized = normalized,
+                CanonicalRequest = canonical
             };
 
             var json = JsonSerializer.Serialize(cacheEntry, CacheSerializerOptions);
             await WriteToFileAsync($"{requestHash}.json", json).ConfigureAwait(false);
             _touchedHashes.TryAdd(requestHash, 0);
+
+            // Keep an already-built index consistent within the same process: a freshly
+            // written fixture's filename label is its key. Avoids a full rescan after record.
+            if (_indexByCachePath.TryGetValue(CurrentCachePath, out var index))
+                index[requestHash] = requestHash;
         }
 
         public async Task<string?> ReadCachedResponseAsync(string requestHash)
@@ -201,20 +219,113 @@ public partial class APISimulator
             ValidateFileName(requestHash);
 
             var json = await ReadFromFileAsync($"{requestHash}.json");
+            var cacheEntry = DeserializeEntry(json);
+            if (cacheEntry?.Response != null)
+                _touchedHashes.TryAdd(requestHash, 0);
+            return cacheEntry;
+        }
+
+        /// <summary>
+        /// Resolves a cache entry by content: first the fast <c>{primaryKey}.json</c> probe,
+        /// then a content-addressed lookup that recomputes each fixture's key from its stored
+        /// <see cref="CanonicalRequest"/> via <paramref name="recompute"/>. This is what makes
+        /// fixtures renameable / hand-authorable and lets a keying-rule change re-baseline
+        /// existing files with zero upstream calls.
+        /// </summary>
+        public async Task<CacheEntry?> ResolveEntryAsync(string primaryKey, Func<CanonicalRequest, string> recompute)
+        {
+            var direct = await ReadCachedEntryAsync(primaryKey).ConfigureAwait(false);
+            if (direct?.Response is { Length: > 0 })
+                return direct;
+
+            // Built once per effective cache path (fixtures are expected to exist before the
+            // first request); our own writes patch it incrementally, context switches drop it.
+            var index = GetOrBuildIndex(CurrentCachePath, recompute);
+            if (index.TryGetValue(primaryKey, out var label))
+            {
+                var json = await ReadFromFileAsync($"{label}.json").ConfigureAwait(false);
+                var matched = DeserializeEntry(json);
+                if (matched?.Response is { Length: > 0 })
+                {
+                    // Track by the on-disk label so stale-removal keeps renamed fixtures.
+                    _touchedHashes.TryAdd(label, 0);
+                    return matched;
+                }
+
+                // Label points at a file that was deleted/renamed mid-run: self-heal so the
+                // failed probe is not repeated for every subsequent matching request.
+                index.TryRemove(primaryKey, out _);
+            }
+
+            return null;
+        }
+
+        private static CacheEntry? DeserializeEntry(string? json)
+        {
             if (string.IsNullOrEmpty(json))
                 return null;
-
             try
             {
-                var cacheEntry = JsonSerializer.Deserialize<CacheEntry>(json);
-                if (cacheEntry?.Response != null)
-                    _touchedHashes.TryAdd(requestHash, 0);
-                return cacheEntry;
+                return JsonSerializer.Deserialize<CacheEntry>(json);
             }
             catch (JsonException)
             {
                 return null;
             }
+        }
+
+        private ConcurrentDictionary<string, string> GetOrBuildIndex(
+            string path, Func<CanonicalRequest, string> recompute)
+        {
+            if (_indexByCachePath.TryGetValue(path, out var existing))
+                return existing;
+
+            lock (_indexLock)
+            {
+                if (_indexByCachePath.TryGetValue(path, out existing))
+                    return existing;
+
+                var index = new ConcurrentDictionary<string, string>();
+                foreach (var file in CacheFiles.JsonFiles(path))
+                {
+                    var label = Path.GetFileNameWithoutExtension(file);
+                    CacheEntry? entry;
+                    try
+                    {
+                        entry = DeserializeEntry(File.ReadAllText(file));
+                    }
+                    catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+                    {
+                        continue;
+                    }
+
+                    if (entry?.CanonicalRequest is { } canonical)
+                    {
+                        try
+                        {
+                            index[recompute(canonical)] = label;
+                        }
+                        catch (Exception ex)
+                        {
+                            System.Diagnostics.Debug.WriteLine(
+                                $"Warning: failed to recompute key for cache file {file}: {ex.Message}");
+                        }
+                    }
+                    else
+                    {
+                        // Legacy fixture: only resolvable by its original hash filename.
+                        index.TryAdd(label, label);
+                    }
+                }
+
+                _indexByCachePath[path] = index;
+                return index;
+            }
+        }
+
+        private void InvalidateIndex()
+        {
+            _indexByCachePath.Clear();
         }
 
         public void RemoveStaleEntries()
@@ -224,20 +335,7 @@ public partial class APISimulator
 
         private void RemoveStaleEntriesFromPath(string path)
         {
-            if (!Directory.Exists(path))
-                return;
-
-            string[] files;
-            try
-            {
-                files = Directory.GetFiles(path, "*.json");
-            }
-            catch (DirectoryNotFoundException)
-            {
-                return;
-            }
-
-            foreach (var file in files)
+            foreach (var file in CacheFiles.JsonFiles(path))
             {
                 var hash = Path.GetFileNameWithoutExtension(file);
                 if (!_touchedHashes.ContainsKey(hash))
@@ -283,20 +381,7 @@ public partial class APISimulator
 
         private static void ClearCacheFromPath(string path)
         {
-            if (!Directory.Exists(path))
-                return;
-
-            string[] files;
-            try
-            {
-                files = Directory.GetFiles(path, "*.json");
-            }
-            catch (DirectoryNotFoundException)
-            {
-                return;
-            }
-
-            foreach (var file in files)
+            foreach (var file in CacheFiles.JsonFiles(path))
             {
                 try
                 {
@@ -323,5 +408,11 @@ public partial class APISimulator
         public List<string> Instructions { get; set; } = new();
         public DateTime Timestamp { get; set; }
         public bool Normalized { get; set; }
+
+        /// <summary>
+        /// The canonical request this fixture matches, written for new entries so the file
+        /// can be renamed or hand-authored. Null for legacy fixtures (matched by filename).
+        /// </summary>
+        public CanonicalRequest? CanonicalRequest { get; set; }
     }
 }

--- a/Augustus/Augustus/PACKAGE_README.md
+++ b/Augustus/Augustus/PACKAGE_README.md
@@ -108,6 +108,13 @@ var simulator = this.CreateAPISimulator("MyAPI", options =>
 });
 ```
 
+Fixtures are **renameable and hand-authorable**: each file stores its `CanonicalRequest` and
+matching is content-based, so the file name is just a label. Keep keys stable across incidental
+request changes with `NormalizeAzureOpenAIDeployment`, `RequestKeyTransform`,
+`IgnoredQueryParameters`, `StripNullBodyProperties`, or `HashMessagesContentOnly`; inspect
+`OnCacheMiss` to discover the expected identity; and re-baseline committed fixtures with zero
+upstream calls via `CacheMaintenance.Rekey`.
+
 ## Route Resolution Order
 
 1. **Route with strategy** — matched route executes its configured `IResponseStrategy`

--- a/Augustus/Augustus/RequestKey.cs
+++ b/Augustus/Augustus/RequestKey.cs
@@ -27,7 +27,28 @@ public sealed record RequestKey(
     string Path,
     string? QueryString,
     IReadOnlyList<string> Instructions,
-    string NormalizedBody);
+    string NormalizedBody)
+{
+    /// <summary>
+    /// Compares by value, with <see cref="Instructions"/> compared element-wise so two
+    /// identities built from equivalent lists are equal regardless of list instance.
+    /// </summary>
+    public bool Equals(RequestKey? other) =>
+        other is not null
+        && Method == other.Method
+        && Path == other.Path
+        && QueryString == other.QueryString
+        && NormalizedBody == other.NormalizedBody
+        && Instructions.SequenceEqual(other.Instructions);
+
+    public override int GetHashCode()
+    {
+        var hash = HashCode.Combine(Method, Path, QueryString, NormalizedBody);
+        foreach (var s in Instructions)
+            hash = HashCode.Combine(hash, s);
+        return hash;
+    }
+}
 
 /// <summary>
 /// The canonical request persisted inside each cache file. This is the projection of a
@@ -54,7 +75,28 @@ public sealed record CanonicalRequest(
     string Path,
     string? QueryString,
     IReadOnlyList<string> Instructions,
-    string NormalizedBody);
+    string NormalizedBody)
+{
+    /// <summary>
+    /// Compares by value, with <see cref="Instructions"/> compared element-wise so two
+    /// canonicals built from equivalent lists are equal regardless of list instance.
+    /// </summary>
+    public bool Equals(CanonicalRequest? other) =>
+        other is not null
+        && Method == other.Method
+        && Path == other.Path
+        && QueryString == other.QueryString
+        && NormalizedBody == other.NormalizedBody
+        && Instructions.SequenceEqual(other.Instructions);
+
+    public override int GetHashCode()
+    {
+        var hash = HashCode.Combine(Method, Path, QueryString, NormalizedBody);
+        foreach (var s in Instructions)
+            hash = HashCode.Combine(hash, s);
+        return hash;
+    }
+}
 
 /// <summary>
 /// Diagnostic information emitted on a cache miss via

--- a/Augustus/Augustus/RequestKey.cs
+++ b/Augustus/Augustus/RequestKey.cs
@@ -1,0 +1,71 @@
+namespace Augustus;
+
+/// <summary>
+/// The identity of an HTTP request used for cache matching, after body normalization
+/// but before hashing. Supplied to and returned from
+/// <see cref="APISimulatorOptions.RequestKeyTransform"/> so consumers can strip or
+/// rewrite volatile parts of the request (for example the Azure OpenAI
+/// <c>/openai/deployments/{deployment}/…</c> path segment) to keep cache keys stable.
+/// </summary>
+/// <param name="Method">The HTTP method (e.g. <c>POST</c>).</param>
+/// <param name="Path">The request path (e.g. <c>/openai/deployments/gpt-4/chat/completions</c>).</param>
+/// <param name="QueryString">The raw query string including the leading <c>?</c>, or <c>null</c>.</param>
+/// <param name="Instructions">The AI instructions that participate in the key, in order.</param>
+/// <param name="NormalizedBody">
+/// The canonicalized request body as a UTF-8 string (sorted JSON keys, normalized
+/// newlines, dynamic fields replaced). Empty when there is no body.
+/// </param>
+/// <remarks>
+/// A request-key transform must be pure, deterministic, and idempotent
+/// (<c>f(f(x)) == f(x)</c>): it is applied to incoming requests and re-applied to each
+/// fixture's already-transformed stored <see cref="CanonicalRequest"/> during content
+/// matching, so a non-idempotent transform breaks matching. The built-in
+/// <see cref="APISimulatorOptions.NormalizeAzureOpenAIDeployment"/> satisfies this.
+/// </remarks>
+public sealed record RequestKey(
+    string Method,
+    string Path,
+    string? QueryString,
+    IReadOnlyList<string> Instructions,
+    string NormalizedBody);
+
+/// <summary>
+/// The canonical request persisted inside each cache file. This is the projection of a
+/// <see cref="RequestKey"/> after all normalization and transforms have been applied —
+/// i.e. exactly what the cache key is computed from. Augustus matches an incoming request
+/// against each fixture's stored <see cref="CanonicalRequest"/>, so the file name is a
+/// free-form label rather than the key itself.
+/// </summary>
+/// <remarks>
+/// This is the matching identity and is persisted to the fixture file <em>verbatim</em> —
+/// it is not run through sensitive-value redaction (unlike the diagnostic
+/// <c>OriginalRequest</c>), because the normalized body/query must round-trip exactly for
+/// content matching to work. Keep secrets out of it with <see cref="APISimulatorOptions"/>
+/// normalization knobs (<see cref="APISimulatorOptions.DynamicContentFields"/>,
+/// <see cref="APISimulatorOptions.IgnoredQueryParameters"/>).
+/// </remarks>
+/// <param name="Method">The HTTP method.</param>
+/// <param name="Path">The request path.</param>
+/// <param name="QueryString">The query string, or <c>null</c>.</param>
+/// <param name="Instructions">The AI instructions that participate in the key, in order.</param>
+/// <param name="NormalizedBody">The canonicalized request body as a UTF-8 string.</param>
+public sealed record CanonicalRequest(
+    string Method,
+    string Path,
+    string? QueryString,
+    IReadOnlyList<string> Instructions,
+    string NormalizedBody);
+
+/// <summary>
+/// Diagnostic information emitted on a cache miss via
+/// <see cref="APISimulatorOptions.OnCacheMiss"/>. Lets a developer discover the exact
+/// identity Augustus expected so a fixture can be authored or renamed by hand even when
+/// the upstream API is unavailable.
+/// </summary>
+/// <param name="ExpectedCanonicalRequest">The canonical request Augustus computed for the incoming request.</param>
+/// <param name="ComputedKey">The cache key (hex SHA-256) computed from <paramref name="ExpectedCanonicalRequest"/>.</param>
+/// <param name="CachePath">The effective cache folder that was searched.</param>
+public sealed record CacheMissDiagnostic(
+    CanonicalRequest ExpectedCanonicalRequest,
+    string ComputedKey,
+    string CachePath);

--- a/Augustus/Augustus/RequestKeyFactory.cs
+++ b/Augustus/Augustus/RequestKeyFactory.cs
@@ -92,15 +92,18 @@ internal static class RequestKeyFactory
         var canonical = new CanonicalRequest(
             key.Method, key.Path, key.QueryString, key.Instructions, key.NormalizedBody);
 
-        // Hash the canonical body string the same way ComputeKeyFromCanonical does so a
-        // just-written fixture resolves byte-identically when later matched via its stored
-        // CanonicalRequest (the invariant the renameable-fixture feature depends on).
-        // For UTF-8 bodies — JSON and form-encoded, i.e. every realistic API request body —
-        // this round-trips exactly and equals the historical key. A request body that is
-        // not valid UTF-8 (raw binary upload) hashes differently than pre-0.9 Augustus and
-        // is resolvable only by its hash filename, not by content; this is an accepted,
-        // documented edge for an API simulator.
-        var hash = ComputeHash(canonical, Encoding.UTF8.GetBytes(canonical.NormalizedBody));
+        // When a transform did not touch the body, hash the original materialized bytes so
+        // the live key is byte-identical to pre-0.9 Augustus (including non-UTF-8 binary
+        // uploads). When the transform did touch the body, hash UTF-8 of the new string so
+        // the transform actually changes the key. ComputeKeyFromCanonical always hashes
+        // UTF-8 of the stored canonical body, so a just-written fixture's stored canonical
+        // recomputes to the same hash for every realistic (UTF-8-representable) body — the
+        // invariant the renameable-fixture feature depends on. Binary-body fixtures remain
+        // resolvable by hash filename only.
+        var bodyForHash = ReferenceEquals(key.NormalizedBody, bodyString) || key.NormalizedBody == bodyString
+            ? materialized
+            : Encoding.UTF8.GetBytes(key.NormalizedBody);
+        var hash = ComputeHash(canonical, bodyForHash);
         return new Result
         {
             Key = key,
@@ -176,7 +179,14 @@ internal static class RequestKeyFactory
         {
             var eq = pair.IndexOf('=');
             var name = eq >= 0 ? pair[..eq] : pair;
-            if (!ignoreSet.Contains(Uri.UnescapeDataString(name)))
+
+            // Malformed percent-encoding (e.g. "?bad=%") must not turn cache-key
+            // computation into a 500 — fall back to comparing the raw, encoded name.
+            string decoded;
+            try { decoded = Uri.UnescapeDataString(name); }
+            catch (UriFormatException) { decoded = name; }
+
+            if (!ignoreSet.Contains(decoded))
                 kept.Add(pair);
         }
 

--- a/Augustus/Augustus/RequestKeyFactory.cs
+++ b/Augustus/Augustus/RequestKeyFactory.cs
@@ -1,5 +1,6 @@
 using System.Security.Cryptography;
 using System.Text;
+using System.Text.Json;
 using System.Text.RegularExpressions;
 
 namespace Augustus;
@@ -185,25 +186,73 @@ internal static class RequestKeyFactory
 
 /// <summary>
 /// Built-in request-key transform that replaces the volatile Azure OpenAI deployment
-/// path segment with a constant so a deployment or region rename does not invalidate
-/// committed fixtures.
+/// path segment AND the top-level <c>"model"</c> field in the JSON request body with
+/// a constant so a deployment or region rename does not invalidate committed fixtures.
+/// Both substitutions are necessary because the deployment name appears in TWO places
+/// in a typical Azure OpenAI chat-completion request: the URL path
+/// (<c>/openai/deployments/{deployment}/chat/completions</c>) and the body's top-level
+/// <c>model</c> property, which the OpenAI SDK populates from the deployment name.
 /// </summary>
 internal static class AzureOpenAINormalization
 {
     private const string DeploymentPlaceholder = "__DEPLOYMENT__";
+    private const string ModelFieldName = "model";
 
     private static readonly Regex DeploymentSegment = new(
         @"(?<prefix>/openai/deployments/)(?<deployment>[^/]+)",
         RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
+    // Must match the encoder used by CacheKeyBodyNormalizer so a re-serialized body
+    // hashes byte-identically to the originally normalized body.
+    private static readonly JsonSerializerOptions BodySerializerOptions = new()
+    {
+        Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+    };
+
     public static RequestKey Apply(RequestKey key)
     {
-        if (string.IsNullOrEmpty(key.Path) || !DeploymentSegment.IsMatch(key.Path))
+        var newPath = NormalizePath(key.Path);
+        var newBody = NormalizeBodyModelField(key.NormalizedBody);
+
+        if (ReferenceEquals(newPath, key.Path) && ReferenceEquals(newBody, key.NormalizedBody))
             return key;
 
-        var normalizedPath = DeploymentSegment.Replace(
-            key.Path, "${prefix}" + DeploymentPlaceholder);
+        return key with { Path = newPath, NormalizedBody = newBody };
+    }
 
-        return normalizedPath == key.Path ? key : key with { Path = normalizedPath };
+    private static string NormalizePath(string path)
+    {
+        if (string.IsNullOrEmpty(path) || !DeploymentSegment.IsMatch(path))
+            return path;
+
+        var replaced = DeploymentSegment.Replace(path, "${prefix}" + DeploymentPlaceholder);
+        return replaced == path ? path : replaced;
+    }
+
+    private static string NormalizeBodyModelField(string body)
+    {
+        // Fast bail-out — avoid parsing for non-JSON or bodies that obviously don't
+        // contain a top-level "model" property.
+        if (string.IsNullOrEmpty(body) || !body.Contains("\"" + ModelFieldName + "\""))
+            return body;
+
+        try
+        {
+            var node = System.Text.Json.Nodes.JsonNode.Parse(body);
+            if (node is System.Text.Json.Nodes.JsonObject obj && obj.ContainsKey(ModelFieldName))
+            {
+                // System.Text.Json.Nodes.JsonObject preserves insertion order. The canonical
+                // body's keys were sorted alphabetically by CacheKeyBodyNormalizer.SortKeysRecursive,
+                // so mutating in place keeps that order — serialization round-trips at the same hash.
+                obj[ModelFieldName] = DeploymentPlaceholder;
+                return obj.ToJsonString(BodySerializerOptions);
+            }
+        }
+        catch (System.Text.Json.JsonException)
+        {
+            // Body looked like JSON but wasn't — leave it alone.
+        }
+
+        return body;
     }
 }

--- a/Augustus/Augustus/RequestKeyFactory.cs
+++ b/Augustus/Augustus/RequestKeyFactory.cs
@@ -58,6 +58,16 @@ internal static class RequestKeyFactory
         public CanonicalRequest Canonical { get; init; }
         public string Hash { get; init; }
         public byte[] MaterializedBody { get; init; }
+
+        /// <summary>
+        /// <c>true</c> when <see cref="Canonical"/> can be re-hashed to <see cref="Hash"/>
+        /// — i.e. the materialized body round-trips losslessly through UTF-8. When
+        /// <c>false</c>, persisting the canonical inside the fixture would make the file
+        /// unresolvable both by fast-path probe (canonical recomputes to a different key)
+        /// and by content index (would map under that wrong key). Handlers must persist
+        /// the entry as legacy (filename-keyed, no canonical) in that case.
+        /// </summary>
+        public bool CanonicalIsRoundtrippable { get; init; }
     }
 
     public static Result Create(
@@ -96,13 +106,25 @@ internal static class RequestKeyFactory
         // the live key is byte-identical to pre-0.9 Augustus (including non-UTF-8 binary
         // uploads). When the transform did touch the body, hash UTF-8 of the new string so
         // the transform actually changes the key. ComputeKeyFromCanonical always hashes
-        // UTF-8 of the stored canonical body, so a just-written fixture's stored canonical
-        // recomputes to the same hash for every realistic (UTF-8-representable) body — the
-        // invariant the renameable-fixture feature depends on. Binary-body fixtures remain
-        // resolvable by hash filename only.
-        var bodyForHash = ReferenceEquals(key.NormalizedBody, bodyString) || key.NormalizedBody == bodyString
-            ? materialized
-            : Encoding.UTF8.GetBytes(key.NormalizedBody);
+        // UTF-8 of the stored canonical body — so for the just-written canonical to
+        // recompute to the same hash, the materialized body must round-trip losslessly
+        // through UTF-8. That holds for every realistic JSON/form payload; for a non-UTF-8
+        // binary upload it does not, and CanonicalIsRoundtrippable signals callers to
+        // persist the entry as legacy (filename-keyed) instead.
+        var bodyChanged = key.NormalizedBody != bodyString;
+        byte[] bodyForHash;
+        bool canonicalIsRoundtrippable;
+        if (bodyChanged)
+        {
+            bodyForHash = Encoding.UTF8.GetBytes(key.NormalizedBody);
+            canonicalIsRoundtrippable = true;
+        }
+        else
+        {
+            bodyForHash = materialized;
+            canonicalIsRoundtrippable = materialized.Length == 0
+                || Encoding.UTF8.GetBytes(bodyString).AsSpan().SequenceEqual(materialized);
+        }
         var hash = ComputeHash(canonical, bodyForHash);
         return new Result
         {
@@ -110,6 +132,7 @@ internal static class RequestKeyFactory
             Canonical = canonical,
             Hash = hash,
             MaterializedBody = materialized,
+            CanonicalIsRoundtrippable = canonicalIsRoundtrippable,
         };
     }
 

--- a/Augustus/Augustus/RequestKeyFactory.cs
+++ b/Augustus/Augustus/RequestKeyFactory.cs
@@ -1,0 +1,209 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace Augustus;
+
+/// <summary>
+/// Normalization rules applied when computing a cache key. The default instance
+/// (<see cref="Legacy"/>) reproduces the historical key byte-for-byte so existing
+/// fixtures keep resolving without a rekey.
+/// </summary>
+internal sealed class CacheKeyRules
+{
+    public IReadOnlyCollection<string>? DynamicContentFields { get; init; }
+    public IReadOnlyCollection<string>? IgnoredQueryParameters { get; init; }
+    public bool NormalizeAzureOpenAIDeployment { get; init; }
+    public Func<RequestKey, RequestKey>? RequestKeyTransform { get; init; }
+    public bool StripNullBodyProperties { get; init; }
+    public bool HashMessagesContentOnly { get; init; }
+
+    public static readonly CacheKeyRules Legacy = new();
+
+    /// <summary>
+    /// Single projection used by both <see cref="APISimulatorOptions"/> and
+    /// <see cref="RekeyOptions"/> so the simulator and the offline rekey tool always derive
+    /// identical rules from the same settings.
+    /// </summary>
+    public static CacheKeyRules From(
+        IReadOnlyList<string> dynamicContentFields,
+        IReadOnlyList<string> ignoredQueryParameters,
+        Func<RequestKey, RequestKey>? requestKeyTransform,
+        bool normalizeAzureOpenAIDeployment,
+        bool stripNullBodyProperties,
+        bool hashMessagesContentOnly) => new()
+    {
+        DynamicContentFields = dynamicContentFields.Count > 0 ? dynamicContentFields.ToArray() : null,
+        IgnoredQueryParameters = ignoredQueryParameters.Count > 0 ? ignoredQueryParameters.ToArray() : null,
+        RequestKeyTransform = requestKeyTransform,
+        NormalizeAzureOpenAIDeployment = normalizeAzureOpenAIDeployment,
+        StripNullBodyProperties = stripNullBodyProperties,
+        HashMessagesContentOnly = hashMessagesContentOnly,
+    };
+}
+
+/// <summary>
+/// Single canonicalization path shared by the request handlers, the content index, and
+/// the offline rekey API. Produces the <see cref="RequestKey"/>, its persisted
+/// <see cref="CanonicalRequest"/> projection, and the cache key (hex SHA-256).
+/// </summary>
+internal static class RequestKeyFactory
+{
+    private static readonly byte[] Separator = Encoding.UTF8.GetBytes("|");
+
+    internal readonly struct Result
+    {
+        public RequestKey Key { get; init; }
+        public CanonicalRequest Canonical { get; init; }
+        public string Hash { get; init; }
+        public byte[] MaterializedBody { get; init; }
+    }
+
+    public static Result Create(
+        string method,
+        string path,
+        string? queryString,
+        byte[] body,
+        IReadOnlyList<string>? instructions,
+        CacheKeyRules? rules)
+    {
+        rules ??= CacheKeyRules.Legacy;
+
+        var fields = rules.DynamicContentFields ?? Array.Empty<string>();
+        var materialized = CacheKeyBodyNormalizer.PrepareBodyForCacheKey(
+            body,
+            fields,
+            rules.StripNullBodyProperties,
+            rules.HashMessagesContentOnly);
+
+        var bodyString = Encoding.UTF8.GetString(materialized);
+        var effectiveQuery = StripIgnoredQueryParameters(queryString, rules.IgnoredQueryParameters);
+        var instructionList = instructions ?? Array.Empty<string>();
+
+        var key = new RequestKey(method, path, effectiveQuery, instructionList, bodyString);
+
+        if (rules.NormalizeAzureOpenAIDeployment)
+            key = AzureOpenAINormalization.Apply(key);
+
+        if (rules.RequestKeyTransform is { } transform)
+            key = transform(key) ?? key;
+
+        var canonical = new CanonicalRequest(
+            key.Method, key.Path, key.QueryString, key.Instructions, key.NormalizedBody);
+
+        // Hash the canonical body string the same way ComputeKeyFromCanonical does so a
+        // just-written fixture resolves byte-identically when later matched via its stored
+        // CanonicalRequest (the invariant the renameable-fixture feature depends on).
+        // For UTF-8 bodies — JSON and form-encoded, i.e. every realistic API request body —
+        // this round-trips exactly and equals the historical key. A request body that is
+        // not valid UTF-8 (raw binary upload) hashes differently than pre-0.9 Augustus and
+        // is resolvable only by its hash filename, not by content; this is an accepted,
+        // documented edge for an API simulator.
+        var hash = ComputeHash(canonical, Encoding.UTF8.GetBytes(canonical.NormalizedBody));
+        return new Result
+        {
+            Key = key,
+            Canonical = canonical,
+            Hash = hash,
+            MaterializedBody = materialized,
+        };
+    }
+
+    /// <summary>
+    /// Recomputes the key from a fixture's stored <see cref="CanonicalRequest"/>, applying the
+    /// same <paramref name="rules"/> as live requests so a keying-rule change re-baselines
+    /// existing fixtures with zero upstream calls.
+    /// </summary>
+    public static string ComputeKeyFromCanonical(CanonicalRequest canonical, CacheKeyRules? rules)
+    {
+        rules ??= CacheKeyRules.Legacy;
+
+        var key = new RequestKey(
+            canonical.Method, canonical.Path, canonical.QueryString,
+            canonical.Instructions, canonical.NormalizedBody);
+
+        if (rules.NormalizeAzureOpenAIDeployment)
+            key = AzureOpenAINormalization.Apply(key);
+
+        if (rules.RequestKeyTransform is { } transform)
+            key = transform(key) ?? key;
+
+        var transformed = new CanonicalRequest(
+            key.Method, key.Path, key.QueryString, key.Instructions, key.NormalizedBody);
+
+        return ComputeHash(transformed, Encoding.UTF8.GetBytes(transformed.NormalizedBody));
+    }
+
+    internal static string ComputeHash(CanonicalRequest canonical, byte[] bodyBytes)
+    {
+        using var sha = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+        sha.AppendData(Encoding.UTF8.GetBytes(canonical.Method));
+        sha.AppendData(Separator);
+        sha.AppendData(Encoding.UTF8.GetBytes(canonical.Path));
+        sha.AppendData(Separator);
+        sha.AppendData(Encoding.UTF8.GetBytes(canonical.QueryString ?? string.Empty));
+        sha.AppendData(Separator);
+        sha.AppendData(bodyBytes);
+
+        var instructions = canonical.Instructions;
+        if (instructions is { Count: > 0 })
+        {
+            sha.AppendData(Separator);
+            sha.AppendData(Encoding.UTF8.GetBytes(instructions.Count.ToString()));
+            foreach (var instruction in instructions)
+            {
+                sha.AppendData(Separator);
+                sha.AppendData(Encoding.UTF8.GetBytes(instruction));
+            }
+        }
+
+        return Convert.ToHexString(sha.GetHashAndReset());
+    }
+
+    private static string? StripIgnoredQueryParameters(string? queryString, IReadOnlyCollection<string>? ignored)
+    {
+        if (ignored is null || ignored.Count == 0 || string.IsNullOrEmpty(queryString))
+            return queryString;
+
+        var ignoreSet = new HashSet<string>(ignored, StringComparer.OrdinalIgnoreCase);
+        var trimmed = queryString.StartsWith('?') ? queryString[1..] : queryString;
+        if (trimmed.Length == 0)
+            return queryString;
+
+        var kept = new List<string>();
+        foreach (var pair in trimmed.Split('&', StringSplitOptions.RemoveEmptyEntries))
+        {
+            var eq = pair.IndexOf('=');
+            var name = eq >= 0 ? pair[..eq] : pair;
+            if (!ignoreSet.Contains(Uri.UnescapeDataString(name)))
+                kept.Add(pair);
+        }
+
+        return kept.Count == 0 ? string.Empty : "?" + string.Join("&", kept);
+    }
+}
+
+/// <summary>
+/// Built-in request-key transform that replaces the volatile Azure OpenAI deployment
+/// path segment with a constant so a deployment or region rename does not invalidate
+/// committed fixtures.
+/// </summary>
+internal static class AzureOpenAINormalization
+{
+    private const string DeploymentPlaceholder = "__DEPLOYMENT__";
+
+    private static readonly Regex DeploymentSegment = new(
+        @"(?<prefix>/openai/deployments/)(?<deployment>[^/]+)",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    public static RequestKey Apply(RequestKey key)
+    {
+        if (string.IsNullOrEmpty(key.Path) || !DeploymentSegment.IsMatch(key.Path))
+            return key;
+
+        var normalizedPath = DeploymentSegment.Replace(
+            key.Path, "${prefix}" + DeploymentPlaceholder);
+
+        return normalizedPath == key.Path ? key : key with { Path = normalizedPath };
+    }
+}

--- a/README.md
+++ b/README.md
@@ -134,6 +134,15 @@ var simulator = this.CreateAPISimulator("MyAPI", options =>
     options.CacheFolderPath = "./mocks";     // Where cache files live (default: ./mocks)
     options.CacheOnly = false;               // Serve only from cache, 503 on miss (default: false)
     options.AutoRemoveStaleCache = true;     // Clean up untouched cache files on dispose (default: true)
+
+    // Stable, renameable, hand-authorable fixtures (see "Cache identity" below)
+    options.NormalizeAzureOpenAIDeployment = true;            // /openai/deployments/{x}/ → constant
+    options.RequestKeyTransform = key => key with { ... };    // strip/rewrite volatile request parts
+    options.IgnoredQueryParameters.Add("_cb");                // drop cache-buster params from the key
+    options.StripNullBodyProperties = true;                   // null vs omitted no longer churns
+    options.HashMessagesContentOnly = true;                   // only messages[].content keys the cache
+    options.OnCacheMiss = d =>                                // discover the expected identity
+        Console.WriteLine($"miss: {d.ComputedKey} {d.ExpectedCanonicalRequest.Path}");
 });
 ```
 
@@ -307,7 +316,18 @@ Features/
 
 ## Caching
 
-Cache file names and `RequestHash` are derived from the HTTP method, path, query string, and a **canonical form of JSON request bodies** (sorted object keys at every depth, plus optional `DynamicContentFields` normalization). Non-JSON bodies use raw bytes. See [`CHANGELOG.md`](CHANGELOG.md) for release notes when this algorithm changes — **upgrades can invalidate existing on-disk caches**.
+Cache keys are derived from the HTTP method, path, query string, and a **canonical form of JSON request bodies** (sorted object keys at every depth, plus optional `DynamicContentFields` normalization). Non-JSON bodies use raw bytes. See [`CHANGELOG.md`](CHANGELOG.md) for release notes when this algorithm changes — **upgrades can invalidate existing on-disk caches**.
+
+### Cache identity (renameable / hand-authorable fixtures)
+
+Each fixture stores its `CanonicalRequest`, and matching is **content-based**: the file name is a free-form label, not the key. So you can:
+
+- **Rename or hand-author** a fixture file to any name — it still resolves.
+- Keep keys stable across incidental request changes with `NormalizeAzureOpenAIDeployment`, `RequestKeyTransform`, `IgnoredQueryParameters`, `StripNullBodyProperties`, or `HashMessagesContentOnly`.
+- Use `OnCacheMiss` (or the diagnostic fields in the `503` body) to discover the exact identity Augustus expected, so a fixture can be authored offline.
+- Re-baseline committed fixtures after a keying-rule change **with zero upstream calls** via `CacheMaintenance.Rekey(path, new RekeyOptions { … })`.
+
+Legacy fixtures without a `CanonicalRequest` keep resolving by their original hash file name, and the default key is unchanged — no rekey is needed unless you opt into a new rule.
 
 Augustus caches responses as JSON files:
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ var simulator = this.CreateAPISimulator("MyAPI", options =>
 
     // Stable, renameable, hand-authorable fixtures (see "Cache identity" below)
     options.NormalizeAzureOpenAIDeployment = true;            // /openai/deployments/{x}/ → constant
-    options.RequestKeyTransform = key => key with { ... };    // strip/rewrite volatile request parts
+    options.RequestKeyTransform = key => key with { Path = "/v1/chat/completions" }; // rewrite volatile parts
     options.IgnoredQueryParameters.Add("_cb");                // drop cache-buster params from the key
     options.StripNullBodyProperties = true;                   // null vs omitted no longer churns
     options.HashMessagesContentOnly = true;                   // only messages[].content keys the cache


### PR DESCRIPTION
## What
Decouples Augustus cache identity from the raw-request hash so recorded fixtures become **human-renameable and hand-authorable**, and incidental request details (most painfully the Azure OpenAI deployment path segment) stop forcing mass cache regeneration. Closes #106.

## Why
Today the cache key is an opaque SHA-256 of method+URL+body and the **filename _is_ that hash**. That makes fixtures unpredictable, impossible to rename or hand-author, and brittle: a deployment/region rename invalidates hundreds of committed `__mocks__` even though the prompt and response are unchanged, and a `CacheOnly` miss gives no way to discover the expected identity.

## Services & Areas Changed
- `Augustus` — `RequestKey`/`CanonicalRequest`/`CacheMissDiagnostic`, `RequestKeyFactory`, `CacheMaintenance.Rekey`, `CacheKeyComputer` (now a façade), `CacheKeyBodyNormalizer` (null-strip / messages-only), `FileManager` (content-addressed index), `APISimulatorOptions` (new knobs)
- `Augustus.AI` — `AIDefaultHandler` / `ProxyDefaultHandler` resolve by content, persist canonical, emit diagnostics; `CacheManager` entry model

## Testing
- New: `RequestKeyTests`, `RequestKeyTransformTests`, `CacheKeyKnobsTests`, `CacheMaintenanceTests`, plus `FileManagerTests` / `CacheOnlyModeTests` / `ProxyCachingTests` additions (rename survives, hand-authored fixture, Azure deployment-agnostic match, transform re-baseline with **zero upstream calls**, legacy fixture still works, diagnostics).
- Pinned historical-hash regression test (independently verified) guards the byte-identical default key.
- Full solution green in **Release** across net8.0/net9.0/net10.0 (Augustus.Tests 168, AI.Tests 81, Stripe 95, GitHub 57, Reqnroll 12, samples) — 0 failures.
- Two `/simplify` multi-agent review passes applied (hot-path regression, key-derivation divergence, dedup, de-reflected error path).

## Breaking Changes
None. Default cache key is byte-identical; `CanonicalRequest` is an additive, nullable persisted field (old readers ignore it, new readers tolerate its absence — tested both directions). Legacy fixtures resolve by their hash filename as before. Edge: a non-UTF-8 raw-binary request body now resolves by hash filename only (documented).

## API Changes
All additive, `sealed`, extend-only. `Augustus.AI` public surface unchanged.

```csharp
var sim = this.CreateAPISimulator("OpenAI", o =>
{
    o.NormalizeAzureOpenAIDeployment = true;          // /openai/deployments/{x}/ → constant
    o.RequestKeyTransform = k => k with { Path = "/v1/chat/completions" };
    o.IgnoredQueryParameters.Add("_cb");
    o.StripNullBodyProperties = true;
    o.HashMessagesContentOnly = true;
    o.OnCacheMiss = d => Console.WriteLine($"{d.ComputedKey} {d.ExpectedCanonicalRequest.Path}");
});

// Re-baseline committed fixtures after a keying-rule change, zero upstream calls:
CacheMaintenance.Rekey("__mocks__", new RekeyOptions { NormalizeAzureOpenAIDeployment = true });
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
